### PR TITLE
Convert package to native namespace package

### DIFF
--- a/readthedocsext/__init__.py
+++ b/readthedocsext/__init__.py
@@ -1,3 +1,0 @@
-"""Namespace package declaration"""
-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,7 @@ classifiers =
     Framework :: Django
 
 [options]
-packages = find:
-namespace_packages = readthedocsext
+packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =


### PR DESCRIPTION
It's not clear why python is having issues sometimes with the load order
of the pkg resource style namespace distribution, but native namespace
seems to confuse python less.

With ext/ext-theme namespace options reconfigured, you should get this:

    >>> import readthedocsext
    >>> import readthedocsext.cdn
    >>> import readthedocsext.theme
    >>> readthedocsext
    <module 'readthedocsext' from '/usr/src/app/checkouts/readthedocs-ext/readthedocsext/__init__.py'>
    >>> readthedocsext.cdn
    <module 'readthedocsext.cdn' from '/usr/src/app/checkouts/readthedocs-ext/readthedocsext/cdn/__init__.py'>
    >>> readthedocsext.theme
    <module 'readthedocsext.theme' from '/usr/src/app/checkouts/ext-theme/readthedocsext/theme/__init__.py'>

The main underlying docker issue still exists with this however, and it
the first issue that most folks are hitting:

https://github.com/readthedocs/readthedocs.org/issues/7805