### PR TITLE
package: include assets (templates/js/css) into the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft readthedocsext/theme/static/
+graft readthedocsext/theme/templates/


### PR DESCRIPTION
Allows to install the package with `pip` including all the assets in the destination.

Documentation: https://packaging.python.org/guides/using-manifest-in/

Closes #23 