### PR TITLE
Example middleware to gate beta access

### DIFF
--- a/readthedocsext/theme/middleware.py
+++ b/readthedocsext/theme/middleware.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.contrib.auth.models import AnonymousUser
+
+
+class BetaAuthenticationMiddleware(AuthenticationMiddleware):
+    def process_request(self, request):
+        """
+        Require special permissions for beta access.
+
+        Require staff flag, but could be feature flag too.
+        """
+        super().process_request(request)
+        if request.user and not request.user.is_staff:
+            request.user = AnonymousUser()


### PR DESCRIPTION
This doesn't require any view changes. Not a super clean implementation,
as this will allow users to log in (the auth backend didn't change), but
will just continually redirect to the login page. This seems fine
though.

Implementation on the application would be adding to middlewares:

```
if self.RTD_EXT_THEME_ENABLED:
    middlewares.append('readthedocsext.theme.middleware.BetaAuthenticationMiddleware')
```

Refs:

- #115 