### PR TITLE
Tune docs links on dashboard

### DIFF
--- a/readthedocsext/theme/templates/projects/base_dashboard.html
+++ b/readthedocsext/theme/templates/projects/base_dashboard.html
@@ -24,11 +24,16 @@
             </a>
             <div class="meta">{% trans "Some resources from our documentation" %}</div>
             <div class="description">
+              <div class="ui mini header">Tutorials</div>
               <div class="ui bulleted list">
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Tutorial: Getting started" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" text="Tutorial: Getting started with Sphinx" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-mkdocs.html" text="Tutorial: Getting started with MkDocs" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Tutorial: Importing your documentation" is_external=True class="item" %}
+                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Getting started" is_external=True class="item" %}
+                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" text="Getting started with Sphinx" is_external=True class="item" %}
+                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-mkdocs.html" text="Getting started with MkDocs" is_external=True class="item" %}
+                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Creating a project" is_external=True class="item" %}
+              </div>
+
+              <div class="ui mini header">Reference</div>
+              <div class="ui bulleted list">
                 {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/index.html" text="Configuration file reference" is_external=True class="item" %}
                 {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/build-customization.html" text="Build process customization" is_external=True class="item" %}
               </div>


### PR DESCRIPTION
Drop redundant "Tutorial:" prefix for a header instead, and split links
up into tutorial/reference lists.