### PR TITLE
Notification about beta release

### DIFF
--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -49,6 +49,12 @@
 
     {% block content-wrapper %}
       <div class="ui very padded container">
+
+        {# Temporal notification while we are in Beta #}
+        <div class="ui message info">
+            This dashboard is currently in Beta. Please report any feedback you may have.
+        </div>
+
         {% block messages %}
           {% include "includes/utils/messages.html" %}
         {% endblock messages %}

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -52,7 +52,9 @@
 
         {# Temporal notification while we are in Beta #}
         <div class="ui message info">
-            This dashboard is currently in Beta. Please report any feedback you may have.
+            This dashboard is currently in beta,
+            you can <a href="https://{{ PRODUCTION_DOMAIN }}">return to the legacy dashboard</a> if you encounter any problems.
+            Feel free to <a href="https://{{ PRODUCTION_DOMAIN }}/support">report any feedback</a> you may have.
         </div>
 
         {% block messages %}


### PR DESCRIPTION
I'd like to start promoting the new Beta dashboard. I think we are ready for it now. I've been using it during the last weeks and I haven't found big issues.

My idea here is to send a notification to all users. I wrote this code that we can use (after improving the copy):

```python
from django.utils.translation import gettext_lazy as_
from readthedocs.notifications.notification import SiteNotification
from messages_extends.constants import SUCCESS_PERSISTENT

class BetaDashboardNotification(SiteNotification):

    success_message = _(
        'We are launching our new <strong>Beta dashboard</strong>. '
        '<a href="https://beta.readthedocs.org/">Give it a try</a> and send us feedback.'  # noqa
    )
    success_level = SUCCESS_PERSISTENT


for u in User.objects.filter(profile__banned=False).iterator():
    BetaDashboardNotification(user=u, success=True).send()
```

This notification will be shown to users on the old dashboard. They can dismiss the notification by clicking on the link or in the cross:


![Screenshot_2023-06-26_09-49-48](https://github.com/readthedocs/ext-theme/assets/244656/8cca93d1-b496-474f-abfa-ae31819a4c93)

Besides, when they arrive to the new beta dashboard they will see another notification saying this instance is in beta and we appreciate them sending back feedback to us. This notification cannot be dismissed on purpose; that's why I put it on the HTML template directly.


![Screenshot_2023-06-26_09-57-06](https://github.com/readthedocs/ext-theme/assets/244656/b736c9a6-1f7c-45ac-976b-4b911cf6badc)
