### PR TITLE
Add unified build list and build detail page title for builds

### DIFF
--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -35,9 +35,7 @@
             <span data-bind="with: {state: {code: state()}, success: success()}">
               {% include "builds/includes/status_icon.html" with build=build size="small" circular=True data_bind=True %}
             </span>
-            {% blocktrans trimmed with build_id=build.pk %}
-              Build #{{ build_id }}
-            {% endblocktrans %}
+            {% include "builds/includes/build_name.html" with build=build is_page_title=True %}
           </div>
 
           <div class="ui basic segment loading padded" data-bind="css: { loading: is_loading() }">

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -21,7 +21,7 @@
     <span class="section">
       {# When used a a page title, link the sections independently #}
       {% if is_page_title %}
-        <a href="{% url "project_version_list" build.version.project.slug %}?version={{ build.version.slug }}">
+        <a href="{% url "projects_detail" build.version.project.slug %}?version={{ build.version.slug }}">
       {% endif %}
 
       {% if build.is_external %}

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -1,0 +1,63 @@
+{% comment %}
+
+  A common include for showing the build name in a heading or title 
+
+  This is a more complex heading than other elements. It uses a breadcrumb to
+  show the version the build was for, as well as the type of build in the case
+  that build is for a pull request version.
+
+  When used as a page title, on the build detail page, show some extra text and
+  nested breadcrumbs that we don't need to show in the build listing. This
+  gives some UI to link back to the build list or the version list. Normally,
+  the whole breadcrumb is linked as single link.
+
+{% endcomment %}
+
+{% load i18n %}
+
+{# When not a page title, treat the entire breadcrumb as a link to the build #}
+{% if not is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
+  <span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
+    <span class="section">
+      {# When used a a page title, link the sections independently #}
+      {% if is_page_title %}
+        <a href="{% url "project_version_list" build.version.project.slug %}?version={{ build.version.slug }}">
+      {% endif %}
+
+      {% if build.is_external %}
+        {{ build.external_version_name | lower | capfirst }}
+        {{ build.version.verbose_name }}
+      {% else %}
+        {# Translators: this renders with the version name, example "Version latest" #}
+        {% blocktrans trimmed with version_name=build.version.verbose_name %}
+          Version {{ version_name }}
+        {% endblocktrans %}
+      {% endif %}
+
+      {% if is_page_title %}
+        </a>
+      {% endif %}
+    </span>
+    {% if is_page_title %}
+      {# When used as a page title, show a section link for the filtered build list #}
+      <span class="divider">/</span>
+      {# Translators: this refers to a list of builds for a single project #}
+      <a class="section" href="{% url "builds_project_list" build.version.project.slug %}?version={{ build.version.slug }}">
+        {% trans "Builds" %}
+      </a>
+    {% endif %}
+    <span class="divider">/</span>
+    <span class="active section">
+      {% if is_page_title %}
+        <a href="{{ build.get_absolute_url }}">
+      {% endif %}
+      <span class="ui grey text">
+        #{{ build.pk }}
+      </span>
+      {% if is_page_title %}
+        </a>
+      {% endif %}
+    </span>
+  </span>
+</a>
+{% if not is_page_title %}</a>{% endif %}

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -1,4 +1,9 @@
-{% comment %}
+{% comment "rst" %}
+
+  Build name
+  ==========
+
+  ``builds/includes/build_name.html``
 
   A common include for showing the build name in a heading or title 
 
@@ -10,6 +15,21 @@
   nested breadcrumbs that we don't need to show in the build listing. This
   gives some UI to link back to the build list or the version list. Normally,
   the whole breadcrumb is linked as single link.
+
+  Template parameters
+  -------------------
+
+  .. describe:: build
+
+     The build instance to generate a name/header for.
+
+  .. describe:: is_page_title
+
+      **Boolean, default=False**. Add full build breadcrumbs and link each
+      section separately. This is used in the build detail page, where we want
+      the breadcrumbs to act more like breadcrumbs and want to link back to the
+      list of version builds. On the build listing page, we only want to link
+      to the build detail page for the build.
 
 {% endcomment %}
 

--- a/readthedocsext/theme/templates/builds/partials/build_list.html
+++ b/readthedocsext/theme/templates/builds/partials/build_list.html
@@ -70,9 +70,7 @@
 {% endblock list_item_icon %}
 
 {% block list_item_header %}
-  <a href="{{ object.get_absolute_url }}">
-    {{ object.version.verbose_name }} #{{ object.pk }}
-  </a>
+  {% include "builds/includes/build_name.html" with build=object %}
   <div class="sub header">
     <div class="item" data-bind="semanticui: { popup: { content: '{{ object.date }}', position: 'top center', delay: { show: 500 }, variation: 'small'}}">
       {# Translators: this will read like "Started 1 month, 3 days ago" #}
@@ -84,7 +82,12 @@
 {% endblock list_item_header %}
 
 {% block list_item_meta_items %}
-  {% if object.commit %}
+  {% if object.is_external %}
+    <a href="{{ object.version.vcs_url }}" class="item" aria-label="{{ object.external_version_name | lower | capfirst }} #{{ object.version.verbose_name }}">
+      <i class="fa-duotone fa-code-pull-request icon"></i>
+      <code>#{{ object.version.verbose_name }}</code>
+    </a>
+  {% elif object.commit %}
     {% with commit=object.commit|slice:"0:8" %}
       {% blocktrans with commit=commit trimmed asvar text_commit %}
         View commit {{ commit }}


### PR DESCRIPTION
This addresses a few issues from #158. The build name used on the build
listing and build detail page both differed prior, and didn't mention
the version name consistently.

- Build detail page just used the build pk
- Build listing page listed all versions as "Version {{ version_name }}",
  even pull request builds, which were "Version 1234" in the build
  listing

Additionally, this adds some hierarchy to the build detail page, showing
an additional layer of nesting for both the version (links to a filtered
version listing) and the build list (links to a filtered build listing).

Closes #158

Build listing:

![image](https://github.com/readthedocs/ext-theme/assets/1140183/14a26d70-69c9-4b1a-a049-32bf0ec77a14)

Build detail:

![image](https://github.com/readthedocs/ext-theme/assets/1140183/54b3cb5a-650f-4708-982e-1190e901b5e4)

UX:

[Screencast from 2023-07-11 12-43-30.webm](https://github.com/readthedocs/ext-theme/assets/1140183/0757c546-7d77-437b-bfcb-ab9addfccc7a)
