### PR TITLE
Addons: allow users to opt-in into the beta addons

### DIFF
--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -15,7 +15,7 @@
 {% block project_edit_content %}
   <div class="ui info message">
     {% blocktrans trimmed %}
-      Read the Docs addons are in beta. Give it a try now!
+      We are in beta! Give it a try now and share your feedback with us by <a href="https://github.com/readthedocs/addons" target="_blank">opening an issue</a>.
     {% endblocktrans %}
   </div>
 

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -1,0 +1,30 @@
+{% extends "projects/project_edit_base.html" %}
+
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+{% block title %}{{ project.name }} - {% trans "Addons" %}{% endblock %}
+
+{% block project_addons_active %}active{% endblock %}
+{% block project_edit_content_header %}{% trans "Addons" %}{% endblock %}
+
+{% block project_edit_sidebar_help_topics %}
+  {% include "includes/elements/link.html" with url="https://blog.readthedocs.com/addons-flyout-menu-beta/" text="Blog post: Addons flyout menu beta" is_external=True class="item" %}
+{% endblock project_edit_sidebar_help_topics %}
+
+{% block project_edit_content %}
+  <div class="ui info message">
+    {% blocktrans trimmed %}
+      Read the Docs addons are in beta. Give it a try now!
+    {% endblocktrans %}
+  </div>
+
+  <form class="ui form"
+      method="post"
+      action="{% url 'projects_addons' project_slug=project.slug %}">
+    {% csrf_token %}
+    {{ form|crispy }}
+
+    <input class="ui primary button" type="submit" value="{% trans "Save" %}">
+  </form>
+{% endblock %}

--- a/readthedocsext/theme/templates/projects/edit_base.html
+++ b/readthedocsext/theme/templates/projects/edit_base.html
@@ -17,6 +17,9 @@
         <a class="item {% block project_advanced_active %}{% endblock %}" href="{% url "projects_advanced" project.slug %}">
           {% trans "Advanced settings" %}
         </a>
+        <a class="item {% block project_addons_active %}{% endblock %}" href="{% url "projects_addons" project.slug %}">
+            {% trans "Addons" %} <i class="ui small grey fa-duotone fa-rocket"></i>
+        </a>
         <a class="item {% block project_domains_active %}{% endblock %}" href="{% url "projects_domains" project.slug %}">
           {% trans "Domains" %}
         </a>

--- a/readthedocsext/theme/templates/projects/edit_base.html
+++ b/readthedocsext/theme/templates/projects/edit_base.html
@@ -18,7 +18,10 @@
           {% trans "Advanced settings" %}
         </a>
         <a class="item {% block project_addons_active %}{% endblock %}" href="{% url "projects_addons" project.slug %}">
-            {% trans "Addons" %} <i class="ui small grey fa-duotone fa-rocket"></i>
+            {% trans "Addons" %}
+            <div class="ui basic primary label">
+                {% trans "Beta" %}
+            </div>
         </a>
         <a class="item {% block project_domains_active %}{% endblock %}" href="{% url "projects_domains" project.slug %}">
           {% trans "Domains" %}


### PR DESCRIPTION
Show a small form to the user where they can enable/disable the new beta addons on their project.

![Screenshot_2023-09-13_16-35-50](https://github.com/readthedocs/ext-theme/assets/244656/39774390-c6a9-4f5f-9bb9-866535889b5a)


* Closes #212
* Requires https://github.com/readthedocs/readthedocs.org/pull/10733