### PR TITLE
Integrations: don't link webhooks to beta domain

### DIFF
--- a/readthedocsext/theme/templates/projects/integration_webhook_detail.html
+++ b/readthedocsext/theme/templates/projects/integration_webhook_detail.html
@@ -20,7 +20,7 @@
     </p>
     <p>
       {% url 'api_webhook' project_slug=project.slug integration_pk=integration.pk as webhook_url %}
-      <a href="//{{ PRODUCTION_DOMAIN }}{{ webhook_url }}">{{ PRODUCTION_DOMAIN }}{{ webhook_url }}</a>
+      <a href="{{ PUBLIC_API_URL }}{{ webhook_url }}">{{ PUBLIC_API_URL }}{{ webhook_url }}</a>
     </p>
   {% else %}
     {% comment %}
@@ -51,7 +51,7 @@
 
     <div class="ui segment">
       {% url 'api_webhook' project_slug=project.slug integration_pk=integration.pk as webhook_url %}
-      {% with "//"|add:PRODUCTION_DOMAIN|add:webhook_url as integration_url %}
+      {% with PUBLIC_API_URL|add:webhook_url as integration_url %}
         <code>{{ integration_url }}</code>
         <span class="ui compact icon basic button" data-clipboard-text="{{ integration_url }}" data-content="{% trans "Copied!" %}">
           <i class="fa-duotone fa-copy icon"></i>


### PR DESCRIPTION
Same as https://github.com/readthedocs/readthedocs.org/pull/10801

![Screenshot 2023-10-09 at 13-26-24 docs - Integrations - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/3de02ee6-68d1-4e53-a667-ff9d7fe0492e)
