### PR TITLE
Translations: add check for supported versioning schemes

### DIFF
--- a/readthedocsext/theme/templates/projects/translation_list.html
+++ b/readthedocsext/theme/templates/projects/translation_list.html
@@ -9,7 +9,21 @@
 {% block project_edit_content_header %}{% trans "Translations" %}{% endblock %}
 
 {% block project_edit_content %}
-  {% if project.main_language_project %}
+  {% if not project.supports_translations %}
+    {% url 'projects_advanced' project_slug=project.slug as advanced_settings_url %}
+    <div class="ui icon message">
+      <i class="fa-duotone fa-circle-exclamation icon"></i>
+      <div class="content">
+        <div class="header">
+          {% trans "Translations are not supported" %}
+        </div>
+      <p>
+      {% blocktrans trimmed with advanced_settings_url=advanced_settings_url %}
+      This project is <a href="{{ advanced_settings_url }}">configured</a> with a versioning scheme that doesn't support translations.
+      {% endblocktrans %}
+      </p>
+    </div>
+  {% elif project.main_language_project %}
     <div class="ui icon message">
       <i class="fa-duotone fa-diagram-nested icon"></i>
       <div class="content">


### PR DESCRIPTION
Port of https://github.com/readthedocs/readthedocs.org/pull/10766

![Screenshot 2023-11-22 at 10-15-05 strong translation _strong - Translations - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/5869635a-002a-4bfb-8249-7d58bcb05359)
