### PR TITLE
Redirects: match recent improvements

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -37,6 +37,34 @@
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
+  {% trans "Move up" as button_up_text %}
+  {% trans "Move down" as button_down_text %}
+  {% if not forloop.first %}
+    <button class="ui icon button"
+            data-bind="click: $root.post_child_form"
+            data-content="{{ button_up_text }}"
+            aria-label="{{ button_up_text }}"
+            title="{{ button_up_text }}">
+      <form method="post" action="{% url 'projects_redirects_insert' project_slug=project.slug redirect_pk=object.pk position=object.position|add:"-1" %}">
+        {% csrf_token %}
+      </form>
+      <i class="fa-solid fa-arrow-up icon"></i>
+    </button>
+  {% endif %}
+
+  {% if not forloop.last %}
+    <button class="ui icon button"
+            data-bind="click: $root.post_child_form"
+            data-content="{{ button_down_text }}"
+            aria-label="{{ button_down_text }}"
+            title="{{ button_down_text }}">
+      <form method="post" action="{% url 'projects_redirects_insert' project_slug=project.slug redirect_pk=object.pk position=object.position|add:"1" %}">
+        {% csrf_token %}
+      </form>
+      <i class="fa-solid fa-arrow-down icon"></i>
+    </button>
+  {% endif %}
+
   <a class="ui button"
      href="{% url 'projects_redirects_edit' project_slug=project.slug redirect_pk=object.pk %}"
      data-content="{% trans "Edit redirect" %}">
@@ -79,13 +107,10 @@
         <span>/</span><span class="ui violet text">$version</span>
       {% endif %}
       <span>{{ object.from_url }}</span>
-      {% if object.redirect_type == "prefix" %}
-        <span class="ui violet text">$1</span>
-      {% endif %}
     {% else %}
-      {% if object.redirect_type == "sphinx_html" %}
+      {% if object.redirect_type == "clean_url_to_html" %}
         <span>/**/</span><span class="ui violet text">$1</span><span>/</span>
-      {% elif object.redirect_type == "sphinx_htmldir" %}
+      {% elif object.redirect_type == "html_to_clean_url" %}
         <span>/**/</span><span class="ui violet text">$1</span><span>.html</span>
       {% endif %}
     {% endif %}
@@ -95,18 +120,15 @@
     <label>{% trans "Redirect to:" %}</label>
     {% spaceless %}
       {% if object.from_url %}
-        {% if object.redirect_type == "page" or object.redirect_type == "prefix" %}
+        {% if object.redirect_type == "page" %}
           <span>/</span><span class="ui violet text">$lang</span>
           <span>/</span><span class="ui violet text">$version</span>
-          {% if object.redirect_type == "prefix" %}
-            <span>/</span><span class="ui violet text">$1</span>
-          {% endif %}
         {% endif %}
         <span>{{ object.to_url }}</span>
       {% else %}
-        {% if object.redirect_type == "sphinx_html" %}
+        {% if object.redirect_type == "clean_url_to_html" %}
           <span>/**/</span><span class="ui violet text">$1</span><span>.html</span>
-        {% elif object.redirect_type == "sphinx_htmldir" %}
+        {% elif object.redirect_type == "html_to_clean_url" %}
           <span>/**/</span><span class="ui violet text">$1</span><span>/</span>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
Matches https://github.com/readthedocs/readthedocs.org/pull/10881/.

Applied the same code we have for automation rules.

![redirects](https://github.com/readthedocs/ext-theme/assets/4975310/62d8f1f8-9360-4a26-916c-7a0fad6ef170)

There are some new options that we may want to include in the UI, like status code, description, and if the redirect is enabled/disabled. We can also think about implementing some nice drag and drop in addition to the arrow buttons.
