### PR TITLE
Improve performance of table listing for large querysets

### DIFF
--- a/readthedocsext/theme/templates/includes/crud/table_list.html
+++ b/readthedocsext/theme/templates/includes/crud/table_list.html
@@ -101,10 +101,17 @@
   {% endblock top_menu %}
 
   {% comment %}
-    Testing for boolean here is not efficient, but we support both querysets and arrays here #}
-    {% if not objects.exists %}
+    We usually pass in a queryset here, but some views emit arrays of objects
+    instead, so we support these as well. Therefore, the check here needs to be
+    for an empty array or an empty queryset. Because Django templates aim to
+    be as difficult as possible to use, this conditional looks pretty silly.
+
+    This cannot be a simple `if not objects` as this performs poorly when
+    there are many objects returned in the queryset.
+
+    Order on the conditional matters here, `and` has higher precedence.
   {% endcomment %}
-  {% if not objects %}
+  {% if objects.exists is None and objects|length == 0 or objects.exists == False %}
     {% comment "rst" %}
 
       .. _api-template-list-placeholder:

--- a/readthedocsext/theme/templates/includes/crud/table_list.html
+++ b/readthedocsext/theme/templates/includes/crud/table_list.html
@@ -106,10 +106,16 @@
     for an empty array or an empty queryset. Because Django templates aim to
     be as difficult as possible to use, this conditional looks pretty silly.
 
-    This cannot be a simple `if not objects` as this performs poorly when
-    there are many objects returned in the queryset.
+    This cannot be a simple `if not objects` as this executes the query, which
+    can cause the view to timeout when the query is very large. See ``bool``
+    evaluation in:
 
-    Order on the conditional matters here, `and` has higher precedence.
+    https://docs.djangoproject.com/en/4.2/ref/models/querysets/
+
+    Order on the conditional matters here, `and` has higher precedence. Django
+    templates don't support parenthesis in conditionals.
+
+    https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#boolean-operators
   {% endcomment %}
   {% if objects.exists is None and objects|length == 0 or objects.exists == False %}
     {% comment "rst" %}


### PR DESCRIPTION
Previously, a large queryset would cause a view to timeout, as the
conditional `if objects` ends up inspecting the entire queryset for
some version of truthiness. Instead, a more explicit check for both
empty arrays and empty querysets avoids this overhead.

- Closes #209