### PR TITLE
Improve performance of build list view

### DIFF
--- a/readthedocsext/theme/templates/builds/build_list.html
+++ b/readthedocsext/theme/templates/builds/build_list.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% load privacy_tags %}
+
 {% block title %}{% trans "Builds" %}{% endblock %}
 
 {% block content-header %}
@@ -9,5 +11,6 @@
 {% endblock %}
 
 {% block content %}
-  {% include "builds/partials/build_list.html" with objects=build_qs %}
+  {# Note: consolidated `is_admin` check here for performance. This could be replaced by a more global solution #}
+  {% include "builds/partials/build_list.html" with objects=build_qs is_project_admin=request.user|is_admin:project %}
 {% endblock %}

--- a/readthedocsext/theme/templates/builds/partials/build_list.html
+++ b/readthedocsext/theme/templates/builds/partials/build_list.html
@@ -47,7 +47,8 @@
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_menu %}
-  {% if request.user|is_admin:project %}
+  {# Note: for better performance, avoid multiple `is_admin` checks. Call this include with `is_project_admin` #}
+  {% if is_project_admin is not None and is_project_admin or request.user|is_admin:project %}
     <form method="post" action="{% url "projects_detail" project.slug %}">
       {% csrf_token %}
       <input type="hidden" name="version_slug" value="{{ object.version.slug }}">


### PR DESCRIPTION
This consolidates all of the build list checks for `is_admin:project`
into a single template variable for now. This replicates what we're
doing at the view level in other views.

Ongoing discussion for a long term approach is at #49

- Refs #128