### PR TITLE
Improvements for filter forms

### DIFF
--- a/readthedocsext/theme/templates/includes/filters/form.html
+++ b/readthedocsext/theme/templates/includes/filters/form.html
@@ -3,32 +3,22 @@
     {% if field.is_hidden %}
       <input type="hidden" name="{{ field.name }}" value="{% if field.value.0|length == 1 %}{{ field.value|default:"" }}{% else %}{{ field.value.0|default:"" }}{% endif %}" />
     {% else %}
-      <div class="header item">
-        <div class="ui manual dropdown" data-bind="semanticui: {dropdown: filter_config}">
-
-          {% comment %}
-            Django-filter sometimes returns a string for the value, sometimes a list.
-            Django doesn't surface a way to do this check in templates and this
-            doesn't warrant a custom filter. This is a hack for now, I'm sorry.
-
-            This should be replaced by a template filter that determines if the
-            value is an iterable of strings, or an iterable of a characters (str).
-
-            This assumes if the first element length == 1, we are iterating
-            over a string (iterable of characters). So, uh, don't use field
-            values of length 1.
-          {% endcomment %}
-          <input type="hidden" name="{{ field.name }}" value="{% if field.value.0|length == 1 %}{{ field.value|default:"" }}{% else %}{{ field.value.0|default:"" }}{% endif %}" />
-          <div class="text">
-            {% if field.value %}<span class="ui floating tiny empty circular olive label"></span>{% endif %}
-            {{ field.label }}
-          </div>
-          <i class="fa-solid fa-caret-down icon"></i>
-
-          <div class="menu">
-            {% for value, label in field.field.widget.choices %}
-              <a class="item" data-value="{{ value }}">{{ label }}</a>
-            {% endfor %}
+      <div class="item">
+        <div class="content">
+          <div class="ui manual dropdown" data-bind="semanticui: {dropdown: filter_config}">
+            <input type="hidden" name="{{ field.name }}" value="{% if field.value.0|length == 1 %}{{ field.value|default:"" }}{% else %}{{ field.value.0|default:"" }}{% endif %}" />
+            <div class="ui sub header">
+              {{ field.label|safe }}
+              <i class="fa-solid fa-caret-down small icon"></i>
+            </div>
+            <div class="text">
+              {{ field.field.empty_label|safe }}
+            </div>
+            <div class="menu">
+              {% for value, label in field.field.widget.choices %}
+                <a class="item" data-value="{{ value }}">{{ label|safe }}</a>
+              {% endfor %}
+            </div>
           </div>
         </div>
       </div>

--- a/src/js/organization/index.js
+++ b/src/js/organization/index.js
@@ -44,7 +44,7 @@ export class OrganizationListView {
     });
 
     this.filter_config = {
-      action: "select",
+      action: "activate",
       onChange: (value, label, $elem) => {
         // Note: limit use of jQuery selector aid. It's confusing to mix Django
         // templates, knockout, and random jQuery selections in the page. Most


### PR DESCRIPTION
I have wanted to play with these more. This is the templates used for
the filters at the top of model listing views.

A couple changes I've wanted:

- All filters are actual filter instances. Project, version, and
  organization have some one-off, pseudo filters made in HTML
- Filter form shows fields as a `ui sub header` with the label above the
  selected field value. This shows the active filter and value, instead
  of hiding the value
- I want to add an icon for filters
- Filters should use `active` mode from SUI config. This changes the
  default text in the dropdown.

Leaving this open for now so I can return. I was playing with this for
unrelated reasons.

![image](https://github.com/readthedocs/ext-theme/assets/1140183/d53b7674-2678-4f15-98e6-bf325b84a64a)

----

TODO:

- [ ] CSS on `.ui.sub.header` `margin-top`
- [ ] First value is always the shown value, not the selected value
- [ ] #343 needs to happen first, these filters throw off the other elements

----

- Fixes #344