### PR TITLE
Notifications: show attached to `User`, `Project` and `Organization`

### DIFF
--- a/readthedocsext/theme/templates/includes/utils/messages.html
+++ b/readthedocsext/theme/templates/includes/utils/messages.html
@@ -7,6 +7,23 @@
   page content pane.
 {% endcomment %}
 
+{% comment %}
+``user_notifications`` comes from a Context Processor.
+We need to use a CustomUser to have access to "user.notifications"
+See https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-AUTH_USER_MODEL
+{% endcomment %}
+{% if user_notifications %}
+  {% for notification in user_notifications %}
+    <div class="ui message">
+    {% comment %}
+    Add this Xmark here once we implement dismissing notifications.
+    <i class="fa-duotone fa-circle-xmark close icon"></i>
+    {% endcomment %}
+      {{ notification.get_message.get_rendered_body|safe }}
+    </div>
+  {% endfor %}
+{% endif %}
+
 {% if messages %}
   {% for message in messages %}
     {% comment %}

--- a/readthedocsext/theme/templates/organizations/partials/header.html
+++ b/readthedocsext/theme/templates/organizations/partials/header.html
@@ -23,7 +23,7 @@ is_collapsed (default: True)
   {# Render all the notifications attached to the organization.#}
   {% for notification in organization.notifications.all %}
     <div class="ui message">
-      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
+      <i class="{{ notification.get_message.get_display_icon_classes }} icon"></i>
       <span>{{ notification.get_message.get_rendered_body|safe }}</span>
     </div>
   {% endfor %}

--- a/readthedocsext/theme/templates/organizations/partials/header.html
+++ b/readthedocsext/theme/templates/organizations/partials/header.html
@@ -126,4 +126,13 @@ is_collapsed (default: True)
     </div>
   {% endblock organization_header_navigation %}
 
+{# Render all the notifications attached to the organization.#}
+  {% for notification in organization.notifications.all %}
+    <div class="ui message">
+      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
+      <span>{{ notification.get_message.get_rendered_body|safe }}</span>
+    </div>
+  {% endfor %}
+
+
 {% endblock organization_header %}

--- a/readthedocsext/theme/templates/organizations/partials/header.html
+++ b/readthedocsext/theme/templates/organizations/partials/header.html
@@ -20,6 +20,16 @@ is_collapsed (default: True)
 {% endcomment %}
 
 {% block organization_header %}
+  {# Render all the notifications attached to the organization.#}
+  {% for notification in organization.notifications.all %}
+    <div class="ui message">
+      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
+      <span>{{ notification.get_message.get_rendered_body|safe }}</span>
+    </div>
+  {% endfor %}
+
+
+
   <div class="ui top attached segment" data-bind="using: CollapsingHeaderView({{ is_collapsed|default_if_none:True|yesno:"true,false" }})">
 
     {% block organization_header_metadata %}
@@ -125,14 +135,5 @@ is_collapsed (default: True)
       {% endif %}
     </div>
   {% endblock organization_header_navigation %}
-
-{# Render all the notifications attached to the organization.#}
-  {% for notification in organization.notifications.all %}
-    <div class="ui message">
-      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
-      <span>{{ notification.get_message.get_rendered_body|safe }}</span>
-    </div>
-  {% endfor %}
-
 
 {% endblock organization_header %}

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -23,7 +23,7 @@ is_collapsed (default: True)
   {# Render all the notifications attached to the project.#}
   {% for notification in project.notifications.all %}
     <div class="ui message">
-      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
+      <i class="{{ notification.get_message.get_display_icon_classes }} icon"></i>
       <span>{{ notification.get_message.get_rendered_body|safe }}</span>
     </div>
   {% endfor %}

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -201,4 +201,12 @@ is_collapsed (default: True)
     </div>
   {% endblock project_header_navigation %}
 
+{# Render all the notifications attached to the project.#}
+  {% for notification in project.notifications.all %}
+    <div class="ui message">
+      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
+      <span>{{ notification.get_message.get_rendered_body|safe }}</span>
+    </div>
+  {% endfor %}
+
 {% endblock project_header %}

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -20,6 +20,14 @@ is_collapsed (default: True)
 {% endcomment %}
 
 {% block project_header %}
+  {# Render all the notifications attached to the project.#}
+  {% for notification in project.notifications.all %}
+    <div class="ui message">
+      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
+      <span>{{ notification.get_message.get_rendered_body|safe }}</span>
+    </div>
+  {% endfor %}
+
   <div class="ui top attached segment" data-bind="using: CollapsingHeaderView({{ is_collapsed|default_if_none:True|yesno:"true,false" }})">
 
     {% block project_header_metadata %}
@@ -200,13 +208,5 @@ is_collapsed (default: True)
       {% endif %}
     </div>
   {% endblock project_header_navigation %}
-
-{# Render all the notifications attached to the project.#}
-  {% for notification in project.notifications.all %}
-    <div class="ui message">
-      <i class="fa-solid {{ notification.get_message.get_display_icon_classes }}"></i>
-      <span>{{ notification.get_message.get_rendered_body|safe }}</span>
-    </div>
-  {% endfor %}
 
 {% endblock project_header %}


### PR DESCRIPTION
Render notifications attached to these objects.
This is the first pass of this work and there are some things we need to make decisions and improve.

- Where (what pages) these notifications should render?
- How "global" they should be considered?

Note we are rendering these notifications in the template for now, but in the future they will be rendered using the APIv3: #259

### Screenshots

#### User

![Screenshot_2024-01-11_11-01-33](https://github.com/readthedocs/ext-theme/assets/244656/40acdbd4-58af-4abe-87c4-1abbef0b8aca)


#### Project

![Screenshot_2024-01-11_11-01-40](https://github.com/readthedocs/ext-theme/assets/244656/0ce0858e-27f5-4611-8f0f-5930d804bfd2)

#### Organization

![Screenshot_2024-01-11_11-01-16](https://github.com/readthedocs/ext-theme/assets/244656/1cca8ba0-16d3-4156-8688-6cf24fb50aa6)


Closes #260 