### PR TITLE
Addons: leave Crispy forms to handle the rendering of the form

### DIFF
--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -19,12 +19,8 @@
     {% endblocktrans %}
   </div>
 
-  <form class="ui form"
-        method="post"
-        action="{% url 'projects_addons' project_slug=project.slug %}">
-    {% csrf_token %}
-    {{ form|crispy }}
+  <div class="ui form">
+    {% crispy form %}
+  </div>
 
-    <input class="ui primary button" type="submit" value="{% trans "Save" %}">
-  </form>
 {% endblock %}


### PR DESCRIPTION
This is the correct way to render a Crispy form.
It's also required for https://github.com/readthedocs/ext-theme/issues/211