### PR TITLE
Admin: render "advanced form" with crispy filter

### DIFF
--- a/readthedocsext/theme/templates/projects/settings_advanced_form.html
+++ b/readthedocsext/theme/templates/projects/settings_advanced_form.html
@@ -8,9 +8,11 @@
 {% block project_advanced_active %}active{% endblock %}
 
 {% block project_edit_content %}
-  <div class="ui form">
-    {% crispy form %}
-  </div>
+  <form class="ui form" method="post" action=".">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <input class="ui primary button" type="submit" value="{% trans "Save" %}" />
+  </form>
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}


### PR DESCRIPTION
We removed the crispy `Layout` in
https://github.com/readthedocs/readthedocs.org/pull/11036 and there is no need to render the form using the template tag as we were doing.

This matches the changes done in the linked PR.