### PR TITLE
Fix issues stemming from builds with null versions

### DIFF
--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -17,19 +17,19 @@
       <div class="ui top attached segment">
         <div class="ui stackable grid">
 
-        {# Build progress on the left #}
+          {# Build progress on the left #}
           {% block build_detail_metadata_left %}
             <div class="ui eleven wide column">
               <div class="ui header">
-            {% comment %}
-              The state icon expects the build API response directly instead, so
-              we recreate the used fields here.
+                {% comment %}
+                  The state icon expects the build API response directly instead, so
+                  we recreate the used fields here.
 
-              The `data_bind` attribute is used when the build has not finished
-              yet -- when we can expect the page might update with a new build
-              state. Otherwise, it's skipped and we can assume there is no data
-              binding.
-            {% endcomment %}
+                  The `data_bind` attribute is used when the build has not finished
+                  yet -- when we can expect the page might update with a new build
+                  state. Otherwise, it's skipped and we can assume there is no data
+                  binding.
+                {% endcomment %}
                 <span data-bind="with: {state: {code: state()}, success: success()}">
                   {% include "builds/includes/status_icon.html" with build=build size="small" circular=True data_bind=True %}
                 </span>
@@ -45,7 +45,7 @@
             </div>
           {% endblock build_detail_metadata_left %}
 
-        {# Build metadata on the right #}
+          {# Build metadata on the right #}
           {% block build_detail_metadata_right %}
             <div class="ui five wide middle aligned column">
               <div class="ui relaxed list">
@@ -63,17 +63,17 @@
                   </div>
                 </div>
 
-            {# Version type is static, so we can skip some KO code #}
+                {# Version type is static, so we can skip some KO code #}
                 <div class="item">
                   <i class="grey fa-duotone {{ build.is_external | yesno:"fa-code-pull-request,fa-tag" }} icon"></i>
                   <div class="content" data-bind="if: !is_loading()">
                     {% if build.is_external %}
                       {{ build.external_version_name | lower | capfirst }}
-                      <a href="{{ build.version.vcs_url }}"><code>#{{ build.version.verbose_name }}</code></a>
+                      <a href="{{ build.version.vcs_url }}"><code>#{{ build.get_version_name }}</code></a>
                     {% else %}
                       <code>
-                        <a href="{% url "builds_project_list" build.version.project.slug %}?version={{ build.version.slug }}">
-                          {{ build.version.slug }}
+                        <a href="{% url "builds_project_list" build.project.slug %}?version={{ build.get_version_slug }}">
+                          {{ build.get_version_name }}
                         </a>
                       </code>
                     {% endif %}
@@ -114,7 +114,7 @@
           <a
             class="item ko hidden"
             data-bind="click: $root.post_child_form, css: { hidden: !can_cancel() }">
-            <form method="post" action="{% url "builds_detail" build.version.project.slug build.pk %}">
+            <form method="post" action="{% url "builds_detail" build.project.slug build.pk %}">
               {% csrf_token %}
             </form>
             <i class="fas fa-xmark-large red icon"></i>
@@ -130,7 +130,7 @@
               data-bind="click: $root.post_child_form, css: { hidden: !can_retry() }">
               <form method="post" name="rebuild_commit" action="{% url "builds_project_list" project.slug %}">
                 {% csrf_token %}
-                <input type="hidden" name="version_slug" value="{{ build.version.slug }}">
+                <input type="hidden" name="version_slug" value="{{ build.get_version_slug }}">
                 <input type="hidden" name="build_pk" value="{{ build.pk }}">
               </form>
               <i class="fas fa-arrows-rotate icon"></i>

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -205,54 +205,54 @@
         </div>
       {% endif %}
 
-        <div class="ui inverted bottom attached segment transition slide">
+      <div class="ui inverted bottom attached segment transition slide">
 
         {% comment %}
           This is a loading placeholder. The extra element is to fill out the
           extra space in the div
         {% endcomment %}
-          <div class="ui hidden active dimmer" data-bind="visible: is_loading()">
-            <div class="ui text loader">Loading</div>
-          </div>
-          <div class="ui basic segment very padded" data-bind="visible: is_loading()"></div>
-
-          <table
-            class="ui small very basic compact inverted selectable command table"
-            data-bind="visible: commands, foreach: commands"
-            style="display: none;">
-            <tbody>
-              <tr class="top aligned command" data-bind="visible: is_visible() || $parent.show_debug()">
-                <td class="collapsing">
-                  <a class="ui icon left floated" data-bind="click: toggle_expanded">
-                    <i class="grey fa-solid fa-angle-right icon" data-bind="class: is_expanded() ? 'fa-angle-down' : 'fa-angle-right'"></i>
-                  </a>
-                </td>
-                <td>
-                  <code class="ui text" data-bind="text: command, class: command_class, click: toggle_expanded"></code>
-                  <a class="ui mini inverted label" data-bind="text: run_time() + 's'"></a>
-                  <a class="ui mini inverted label" data-bind="text: '{% trans "Exit" %}: ' + exit_code(), visible: exit_code() > 0"></a>
-                </td>
-              </tr>
-            </tbody>
-            <tbody data-bind="visible: is_expanded(), foreach: output_lines">
-              <tr data-bind="css: {'left olive marked': is_selected()}" class="top aligned">
-                <td class="collapsing line number">
-                  <a class="ui small grey left floated text" data-bind="attr: {href: '#' + anchor_id(), 'data-selected': is_selected()}, click: function() { $parents[1].set_selected_line($data) }">
-                    <code data-bind="text: line_number()"></code>
-                  </a>
-                </td>
-                <td class="stdout">
-                  <code data-bind="html: output"></code>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-
-          <div data-bind="visible: is_polling() && !is_loading()" style="display: none;">
-            <div data-bind="visible: is_polling" class="ui active inverted mini centered inline text loader"></div>
-          </div>
-
+        <div class="ui hidden active dimmer" data-bind="visible: is_loading()">
+          <div class="ui text loader">Loading</div>
         </div>
+        <div class="ui basic segment very padded" data-bind="visible: is_loading()"></div>
+
+        <table
+          class="ui small very basic compact inverted selectable command table"
+          data-bind="visible: commands, foreach: commands"
+          style="display: none;">
+          <tbody>
+            <tr class="top aligned command" data-bind="visible: is_visible() || $parent.show_debug()">
+              <td class="collapsing">
+                <a class="ui icon left floated" data-bind="click: toggle_expanded">
+                  <i class="grey fa-solid fa-angle-right icon" data-bind="class: is_expanded() ? 'fa-angle-down' : 'fa-angle-right'"></i>
+                </a>
+              </td>
+              <td>
+                <code class="ui text" data-bind="text: command, class: command_class, click: toggle_expanded"></code>
+                <a class="ui mini inverted label" data-bind="text: run_time() + 's'"></a>
+                <a class="ui mini inverted label" data-bind="text: '{% trans "Exit" %}: ' + exit_code(), visible: exit_code() > 0"></a>
+              </td>
+            </tr>
+          </tbody>
+          <tbody data-bind="visible: is_expanded(), foreach: output_lines">
+            <tr data-bind="css: {'left olive marked': is_selected()}" class="top aligned">
+              <td class="collapsing line number">
+                <a class="ui small grey left floated text" data-bind="attr: {href: '#' + anchor_id(), 'data-selected': is_selected()}, click: function() { $parents[1].set_selected_line($data) }">
+                  <code data-bind="text: line_number()"></code>
+                </a>
+              </td>
+              <td class="stdout">
+                <code data-bind="html: output"></code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div data-bind="visible: is_polling() && !is_loading()" style="display: none;">
+          <div data-bind="visible: is_polling" class="ui active inverted mini centered inline text loader"></div>
+        </div>
+
+      </div>
     {% endif %}
 
   </div>

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -41,15 +41,15 @@
   <span class="section">
       {# When used a a page title, link the sections independently #}
     {% if is_page_title %}
-      <a href="{% url "projects_detail" build.version.project.slug %}?version={{ build.version.slug }}">
+      <a href="{% url "projects_detail" build.project.slug %}?version={{ build.get_version_slug }}">
     {% endif %}
 
     {% if build.is_external %}
       {{ build.external_version_name | lower | capfirst }}
-      {{ build.version.verbose_name }}
+      {{ build.get_version_name }}
     {% else %}
-        {# Translators: this renders with the version name, example "Version latest" #}
-      {% blocktrans trimmed with version_name=build.version.verbose_name %}
+      {# Translators: this renders with the version name, example "Version latest" #}
+      {% blocktrans trimmed with version_name=build.get_version_name %}
         Version {{ version_name }}
       {% endblocktrans %}
     {% endif %}
@@ -59,10 +59,10 @@
     {% endif %}
   </span>
   {% if is_page_title %}
-      {# When used as a page title, show a section link for the filtered build list #}
+    {# When used as a page title, show a section link for the filtered build list #}
     <span class="divider">/</span>
-      {# Translators: this refers to a list of builds for a single project #}
-    <a class="section" href="{% url "builds_project_list" build.version.project.slug %}?version={{ build.version.slug }}">
+    {# Translators: this refers to a list of builds for a single project #}
+    <a class="section" href="{% url "builds_project_list" build.project.slug %}?version={{ build.get_version_slug }}">
       {% trans "Builds" %}
     </a>
   {% endif %}


### PR DESCRIPTION
This uses the build methods to get version name/slug instead of expecting
Build.version to always be a valid relationship.

Changes are in 306dd40