### PR TITLE
Fix project create wizard form step

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -255,7 +255,8 @@
           <input type="hidden" name="repo" data-bind="value: clone_url" />
           <input type="hidden" name="repo_type" data-bind="value: vcs" />
           <input type="hidden" name="project_url" data-bind="value: html_url" />
-          <input type="hidden" name="remote_repository" data-bind="value: id" />
+          <input type="hidden" name="remote_repository" data-bind="value: pk" />
+          <input type="hidden" name="default_branch" data-bind="value: default_branch" />
 
           <button class="ui primary button" data-bind="css: {disabled: !admin}">
             {% trans "Continue" %}


### PR DESCRIPTION
Originally raised here:

- https://github.com/readthedocs/readthedocs.org/issues/10842

I wonder if the API data source changed at some point? Either way, the
effect was that the project create form step would submit and not work
(though not raise a validation error either).

I finally noticed this locally today, and in the deploy while testing. I
included a fix for the default branch name, that wasn't auto populating
either.

- Fixes https://github.com/readthedocs/readthedocs.org/issues/10842