### PR TITLE
Add build detail notification to switch back to the normal dashboard

### DIFF
--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -7,6 +7,23 @@
 {% block title %}{{ build.project.name }}{% endblock %}
 
 {% block content-header %}
+  {% block build_detail_beta %}
+    {% comment %}
+      Temporary notification to point to the beta dashboard.
+      url_switch_dashboard comes from the view
+    {% endcomment %}
+    {% if url_switch_dashboard %}
+      <div class="ui small basic fitted center aligned segment">
+        <i class="fad fa-sparkles violet icon"></i>
+        <strong>
+          You are using our new beta dashboard.
+        </strong>
+        <a href="{% url "support" %}">We would love to have your feedback</a>.
+        If you encounter problems,
+        <a href="{{ url_switch_dashboard }}">return to our normal dashboard</a>.
+      </div>
+    {% endif %}
+  {% endblock build_detail_beta %}
   {% include "projects/partials/header.html" with builds_active="active" %}
 {% endblock %}
 


### PR DESCRIPTION
This adds a notification to just the detail view that links directly back to the same page on the normal dashboard.

![image](https://github.com/readthedocs/ext-theme/assets/1140183/b5d4adc9-a507-4ae8-9d2f-c55da4c6059b)

- Requires https://github.com/readthedocs/readthedocs.org/pull/11208
- Fixes #284
- Refs https://github.com/readthedocs/readthedocs.org/issues/11209