### PR TITLE
Port CAS related changes

### DIFF
--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -36,10 +36,10 @@
         </a>
 
         {# If allowed providers is given, disable the username/password form #}
+        {% blocktrans asvar text_email_disabled %}Log in using email is disabled for this organization{% endblocktrans %}
         <a class="item {% if allowed_providers %}disabled{% endif %}"
            data-tab="email"
            {% if allowed_providers %}
-           {% trans "Log in using email is disabled for this organization" asvar text_email_disabled %}
            data-content="{{ text_email_disabled }}"
            aria-label="{{ text_email_disabled }}"
            {% endif %}>

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -39,8 +39,9 @@
         <a class="item {% if allowed_providers %}disabled{% endif %}"
            data-tab="email"
            {% if allowed_providers %}
-           title="Log in using email is not enabled for this organization"
-           aria-label="Log in using email is not enabled for this organization"
+           {% trans "Log in using email is disabled for this organization" asvar text_email_disabled %}
+           data-content="{{ text_email_disabled }}"
+           aria-label="{{ text_email_disabled }}"
            {% endif %}>
           <i class="fad fa-envelope icon"></i>
           {% block authentication_email_text %}{% trans "Log in with email" %}{% endblock %}

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -24,7 +24,10 @@
         {% endblock authentication_header %}
       </div>
 
-      <div class="ui small stackable secondary two item menu" data-bind="semanticui: {tabs: {history: true, autoTabActivation: false}}">
+      <div
+          {# The password URL is listed as an additional tab if present #}
+          class="ui small stackable secondary item menu {% if project_password_url %}three{% else %}two{% endif %}"
+          data-bind="semanticui: {tabs: {history: true, autoTabActivation: false}}">
 
         {# This is purposely minimal, as the verbiage for "Log in with connected account" is a mountful #}
         <a class="item" data-tab="vcs">

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -32,12 +32,22 @@
           {% block authentication_vcs_text %}{% trans "Connected account" %}{% endblock %}
         </a>
 
-        {% if not allowed_providers %}
-        {# If allowed providers is given, don't show the username/password form #}
-          <a class="item" data-tab="email">
-            <i class="fad fa-envelope icon"></i>
-            {% block authentication_email_text %}{% trans "Log in with email" %}{% endblock %}
-          </a>
+        {# If allowed providers is given, disable the username/password form #}
+        <a class="item {% if allowed_providers %}disabled{% endif %}"
+           data-tab="email"
+           {% if allowed_providers %}
+           title="Log in using email is not enabled for this organization"
+           aria-label="Log in using email is not enabled for this organization"
+           {% endif %}>
+          <i class="fad fa-envelope icon"></i>
+          {% block authentication_email_text %}{% trans "Log in with email" %}{% endblock %}
+        </a>
+
+        {% if project_password_url %}
+        <a class="item" href="{{ project_password_url }}">
+          <i class="fad fa-lock icon"></i>
+          {% trans "Use a password" %}
+        </a>
         {% endif %}
       </div>
 
@@ -74,16 +84,6 @@
           </form>
         {% endblock authentication_email %}
       </div>
-
-      {% if project_password_url %}
-      <div class="ui info message">
-        <i class="fa-duotone fa-lock icon"></i>
-        {% blocktrans trimmed with project_password_url=project_password_url %}
-        Do you have a password to access this documentation?
-        <a href="{{ project_password_url }}">Access here</a>.
-        {% endblocktrans %}
-      </div>
-      {% endif %}
 
       {% block authentication_extra %}{% endblock %}
 

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -76,8 +76,8 @@
       </div>
 
       {% if project_password_url %}
-      {# TODO: make this look nicer! #}
-      <div>
+      <div class="ui info message">
+        <i class="fa-duotone fa-lock icon"></i>
         {% blocktrans trimmed with project_password_url=project_password_url %}
         Do you have a password to access this documentation?
         <a href="{{ project_password_url }}">Access here</a>.

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -16,7 +16,11 @@
 
       <div class="ui medium header">
         {% block authentication_header %}
-          {% trans "Log in to continue" %}
+          {% if is_from_cas_login %}
+            {% trans "Log in to view this documentation" %}
+          {% else %}
+            {% trans "Log in to continue" %}
+          {% endif %}
         {% endblock authentication_header %}
       </div>
 
@@ -28,11 +32,13 @@
           {% block authentication_vcs_text %}{% trans "Connected account" %}{% endblock %}
         </a>
 
-        <a class="item" data-tab="email">
-          <i class="fad fa-envelope icon"></i>
-          {% block authentication_email_text %}{% trans "Log in with email" %}{% endblock %}
-        </a>
-
+        {% if not allowed_providers %}
+        {# If allowed providers is given, don't show the username/password form #}
+          <a class="item" data-tab="email">
+            <i class="fad fa-envelope icon"></i>
+            {% block authentication_email_text %}{% trans "Log in with email" %}{% endblock %}
+          </a>
+        {% endif %}
       </div>
 
       <div class="ui basic center aligned tab segment" data-tab="vcs">
@@ -68,6 +74,16 @@
           </form>
         {% endblock authentication_email %}
       </div>
+
+      {% if project_password_url %}
+      {# TODO: make this look nicer! #}
+      <div>
+        {% blocktrans trimmed with project_password_url=project_password_url %}
+        Do you have a password to access this documentation?
+        <a href="{{ project_password_url }}">Access here</a>.
+        {% endblocktrans %}
+      </div>
+      {% endif %}
 
       {% block authentication_extra %}{% endblock %}
 

--- a/readthedocsext/theme/templates/socialaccount/snippets/provider_list.html
+++ b/readthedocsext/theme/templates/socialaccount/snippets/provider_list.html
@@ -6,6 +6,7 @@
 {% for provider in socialaccount_providers %}
   {# OpenID is not implemented #}
   {% if provider.id != 'bitbucket' %}
+  {% if allowed_providers and provider.id in allowed_providers or not allowed_providers %}
     <li class="item">
       <form class="ui form"
             method="post"
@@ -19,5 +20,6 @@
         </button>
       </form>
     </li>
+  {% endif %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Normal login

![Screenshot 2024-03-19 at 13-15-21 Log in - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/9429c4c7-efad-4523-b6c8-694b01725427)

Login restricted to one provider

![Screenshot 2024-03-19 at 13-15-14 Log in - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/f4452166-0f24-45c6-8544-51145a9055e8)

Login when trying to access a documentation page

![Screenshot 2024-03-19 at 12-52-21 Log in - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/8b138504-fb49-47db-8162-f663cec01f8f)

![Screenshot 2024-03-19 at 13-09-19 Log in - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/8bc29b9d-ee9c-41c0-956a-ed83e2e728b3)
![Screenshot 2024-03-19 at 13-09-15 Log in - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/3d52befd-fee1-4186-9791-4375f2e3bb5a)


Closes https://github.com/readthedocs/ext-theme/issues/276