### PR TITLE
CI: Run pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '20.12'
-      - run: node --version
+          node-version: "20.12"
       - run: npm ci
       - run: npm run lint
       - run: pip install pre-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,9 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.4.7
+  node: circleci/node@5.2.0
 
 commands:
-  run-lint-node:
-    description: "Run Node linting"
-    steps:
-      - checkout
-      - run: npm ci
-      - run: npm run lint
   run-lint-python:
     description: "Run Python linting"
     steps:
@@ -41,16 +36,17 @@ commands:
       - run: npm test
 
 jobs:
-  lint-node:
-    docker:
-      - image: "cimg/node:16.14"
-    steps:
-      - run-lint-node: {}
-  lint-python:
+  lint:
     docker:
       - image: "cimg/python:3.11.8"
     steps:
-      - run-lint-python: {}
+      - node/install:
+          node-version: '20.12'
+      - run: node --version
+      - run: npm ci
+      - run: npm run lint
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files
   build:
     docker:
       - image: "cimg/node:16.14"
@@ -66,7 +62,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - lint-node
-      - lint-python
+      - lint
       - build
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: pip install pre-commit
-      - run: pre-commit run --all-files
+      - run: pre-commit run --from-ref origin/HEAD --to-ref HEAD
   build:
     docker:
       - image: "cimg/node:16.14"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,6 @@ orbs:
   node: circleci/node@5.2.0
 
 commands:
-  run-lint-python:
-    description: "Run Python linting"
-    steps:
-      - checkout
-      - run: pip install djhtml
-      - run: djhtml --check --tabwidth 2 readthedocsext/
   run-build:
     description: "Ensure built assets are up to date"
     steps:
@@ -41,7 +35,7 @@ jobs:
       - image: "cimg/python:3.11.8"
     steps:
       - node/install:
-          node-version: '20.12'
+          node-version: '16.20'
       - run: node --version
       - run: npm ci
       - run: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,9 @@ jobs:
     docker:
       - image: "cimg/python:3.11.8"
     steps:
+      - checkout
       - node/install:
-          node-version: '16.20'
+          node-version: '20.12'
       - run: node --version
       - run: npm ci
       - run: npm run lint

--- a/docs/api/js/webcomponents.rst
+++ b/docs/api/js/webcomponents.rst
@@ -4,10 +4,10 @@ Web components
 Elements
 --------
 
-.. js:autoclass:: NotificationListElement 
+.. js:autoclass:: NotificationListElement
     :members:
 
-.. js:autoclass:: NotificationElement 
+.. js:autoclass:: NotificationElement
     :members:
 
 Views


### PR DESCRIPTION
I did a local run with `pre-commit run --all-files` (the changes on the .rst file come from that), but on CI I'm just checking the last diff as the pre-commit doc recommend.

pre-commit makes use of node internally, so node is needed in that step, also merging the node and python lint jobs into one.

Closes https://github.com/readthedocs/ext-theme/issues/268