### PR TITLE
Render build commands with text binding

### DIFF
--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -274,7 +274,7 @@
                 </a>
               </td>
               <td class="stdout">
-                <code data-bind="html: output"></code>
+                <code data-bind="text: output"></code>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
This was HTML binding as the colored ANSI output used ansiup and sanitize-html to produce colored HTML output. While we are still waiting on that, we can instead use a simple text binding to ensure we never render unsanitized HTML

- Refs #71