### PR TITLE
Fix sign up comment

### DIFF
--- a/readthedocsext/theme/templates/socialaccount/snippets/provider_list.html
+++ b/readthedocsext/theme/templates/socialaccount/snippets/provider_list.html
@@ -4,11 +4,11 @@
 {% get_providers as socialaccount_providers %}
 
 {% for provider in socialaccount_providers %}
-  {#
+  {% comment %}
     - OpenID is not implemented.
     - Bitbucket is deprecated (in favor of their new oauth implementation).
     - SAML is handled in another view, we don't want to list all SAML integrations here.
-  #}
+  {% endcomment %}
   {% if provider.id != 'bitbucket' and provider.id != 'saml' %}
     {% if allowed_providers and provider.id in allowed_providers or not allowed_providers %}
       <li class="item">


### PR DESCRIPTION
We didn't catch this in #325, but the comment is a single line comment,
not a multiline comment.

![image](https://github.com/readthedocs/ext-theme/assets/1140183/57b915ea-85de-4c85-8cef-2abc6ea72431)
