### PR TITLE
Conditionally inject build version chip embed

### DIFF
--- a/readthedocsext/theme/templates/builds/partials/build_list.html
+++ b/readthedocsext/theme/templates/builds/partials/build_list.html
@@ -102,7 +102,10 @@
 {% endblock list_item_meta_items %}
 
 {% block list_item_extra_items %}
-  <div class="item">
-    {% include "includes/elements/chips/version.html" with version=object.version %}
-  </div>
+  {# Builds can have a null version #}
+  {% if object.version %}
+    <div class="item">
+      {% include "includes/elements/chips/version.html" with version=object.version %}
+    </div>
+  {% endif %}
 {% endblock list_item_extra_items %}

--- a/readthedocsext/theme/templates/includes/elements/chips/version.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/version.html
@@ -10,20 +10,22 @@
 {% endblock %}
 
 {% block chip_icon %}
+  {# fmt:off #}
   <i class="fa-solid icon {% spaceless %}
 
     {# Show the type of the version #}
-              {% if version.is_external %}
-                fa-code-pull-request
-              {% elif version.type == 'branch' %}
-                fa-code-branch
-              {% elif version.type == 'tag' %}
-                fa-tag
-              {% else %}
-                fa-code-commit
-              {% endif %}
+    {% if version.is_external %}
+      fa-code-pull-request
+    {% elif version.type == 'branch' %}
+      fa-code-branch
+    {% elif version.type == 'tag' %}
+      fa-tag
+    {% else %}
+      fa-code-commit
+    {% endif %}
 
-            {% endspaceless %}"></i>
+  {% endspaceless %}"></i>
+  {# fmt:off #}
 {% endblock chip_icon %}
 
 {% block chip_text %}


### PR DESCRIPTION
Protect against null build versions, there is nothing to show in these
cases.

- Fixes #251