### PR TITLE
Add better placeholder content for views with filters

### DIFF
--- a/readthedocsext/theme/templates/builds/partials/build_list.html
+++ b/readthedocsext/theme/templates/builds/partials/build_list.html
@@ -16,12 +16,17 @@
 {% endblock %}
 
 {% block list_placeholder_icon_class %}{% endblock %}
-{% block list_placeholder_header %}
-  {% trans "This project doesn't have any builds yet." %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
-  <div class="ui primary button">{% trans "Learn how to get started" %}</div>
-{% endblock list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching builds found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
+  {% trans "This project doesn't have any builds yet" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
+  {% if is_project_admin is not None and is_project_admin or request.user|is_admin:project %}
+    {% trans "Activate a version to start your first build." %}
+  {% endif %}
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_right_menu %}
   {# Note: for better performance, avoid multiple `is_admin` checks. Call this include with `is_project_admin` #}

--- a/readthedocsext/theme/templates/builds/partials/version_list.html
+++ b/readthedocsext/theme/templates/builds/partials/version_list.html
@@ -19,20 +19,25 @@
   {% if is_project_admin %}
     <a href="{% url "project_version_create" project.slug %}" class="ui primary button">
       <i class="fa-solid fa-plus icon"></i>
-      <span class="text">{% trans "Activate version" %}</span>
+      <span class="text">{% trans "Add version" %}</span>
     </a>
   {% endif %}
 {% endblock %}
 
 {% block list_placeholder_icon_class %}{% endblock %}
-{% block list_placeholder_header %}
-  {% trans "No versions found for this project or filter" %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching versions found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
+  {% trans "This project doesn't have any versions yet" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
   {% if is_project_admin %}
-    <div class="ui primary button">{% trans "Activate a version" %}</div>
+    <a href="{% url "project_version_create" project.slug %}" class="ui primary button">
+      {% trans "Add version" %}
+    </a>
   {% endif %}
-{% endblock list_placeholder_text %}
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_start %}
   <tr class="middle aligned" data-bind="using: VersionListItemView({id: {{ object.pk }}, url: '{% url "projects-versions-detail" object.project.slug object.slug %}'})">

--- a/readthedocsext/theme/templates/includes/crud/table_list.html
+++ b/readthedocsext/theme/templates/includes/crud/table_list.html
@@ -156,10 +156,32 @@
             <i class="{% block list_placeholder_icon_class %}{% endblock %} icon"></i>
           {% endblock list_placeholder_icon %}
           {% block list_placeholder_header %}
-            There are no objects here.
+            {# The filter should always be bound, but data might be `{}` #}
+            {% if filter and filter.is_bound and filter.data %}
+              {% block list_placeholder_header_filtered %}
+                {# Filter is active and nothing was found #}
+                {% trans "No results found" %}
+              {% endblock list_placeholder_header_filtered %}
+            {% else %}
+              {% block list_placeholder_header_empty %}
+                {# Filter is active and nothing was found #}
+                {% trans "No objects created yet" %}
+              {% endblock list_placeholder_header_empty %}
+            {% endif %}
           {% endblock list_placeholder_header %}
         </div>
         {% block list_placeholder_text %}
+          <div class="inline">
+            {# The filter should always be bound, but data might be `{}` #}
+            {% if filter and filter.is_bound and filter.data %}
+              {% block list_placeholder_text_filtered %}
+                {% trans "Try changing or removing your filter criteria" %}
+              {% endblock list_placeholder_text_filtered %}
+            {% else %}
+              {% block list_placeholder_text_empty %}
+              {% endblock list_placeholder_text_empty %}
+            {% endif %}
+          </div>
         {% endblock list_placeholder_text %}
       {% endblock list_placeholder %}
     </div>

--- a/readthedocsext/theme/templates/organizations/partials/members_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/members_list.html
@@ -6,17 +6,17 @@
 {% block create_button %}
 {% endblock %}
 
-{% block list_placeholder_header %}
-  {% blocktrans trimmed %}
-    No members found or no matches found for your filter criteria.
-  {% endblocktrans %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching members found" %}
+{% endblock list_placeholder_header_filtered %}
+{# This is a mostly impossible scenario, as owners show in this list #}
+{% block list_placeholder_header_empty %}
+  {% trans "This organization has no members" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
   {% if request.user|is_admin:organization %}
-    <p class="inline">
-      {% blocktrans trimmed %}
-        To add members to your organization, invite new members to an existing organization team.
-      {% endblocktrans %}
-    </p>
+    {% blocktrans trimmed %}
+      To add members to your organization, invite users to an existing organization team.
+    {% endblocktrans %}
   {% endif %}
-{% endblock list_placeholder_text %}
+{% endblock list_placeholder_text_empty %}

--- a/readthedocsext/theme/templates/organizations/partials/organization_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/organization_list.html
@@ -14,39 +14,41 @@
 {% endblock top_left_menu_items %}
 
 {% block create_button %}
-  {# See below for more background on why we conditionally show a create button here #}
+  {% comment %}
+    This view makes some attempt to gate on organization creation, as we  want
+    to avoid sending users through subscription creation accidentally.
+  {% endcomment %}
   {% if request.user and request.user.organizations.count == 0 %}
     {% trans "Add organization" as create_text %}
-    {% include "includes/crud/create_button.html" with url=organization_create text=create_text %}
+    {% url "organization_create" as create_url %}
+    {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
   {% endif %}
 {% endblock %}
 
-{% comment %}
-  We are specific to check whether an organization exists here as we do not want
-  the user creating a new organization accidentally. This view can be used with
-  an active filter, so Organization.objects.count == 0 does not necessarily imply
-  that the user doesn't below to an organization. Instead this means the user
-  selected a filter that returns no organizations (typo, etc?)
-{% endcomment %}
 {% block list_placeholder_icon_class %}fad fa-building icon{% endblock %}
-{% block list_placeholder_header %}
-  {# TODO this should probably be application logic to consolidate DB queries #}
-  {% if request.user and request.user.organizations.count == 0 %}
-    {% blocktrans trimmed %}
-      You are not a member of an organization yet.
-      To start a free trial, create a new organization.
-    {% endblocktrans %}
-  {% else %}
-    {% blocktrans trimmed %}
-      No organizations match your filter criteria.
-    {% endblocktrans %}
-  {% endif %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
-  {% if request.user and request.user.organizations.count == 0 %}
-    <div class="ui primary button">{% trans "Create an organization" %}</div>
-  {% endif %}
-{% endblock list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching organizations found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
+  {% trans "You are not a member of an organization yet" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
+  {% comment %}
+    This should be stronger onboarding on how to find an existing organization
+    and other steps besides recommending the user create a new organization.
+
+    See: https://github.com/readthedocs/readthedocs.org/issues/11356
+  {% endcomment %}
+  <div class="ui center aligned basic fitted segment">
+    <p>
+      {% blocktrans trimmed %}
+        If you already have an existing organization, you may need to ask to be
+        invited to your organization again, or you may have signed in with the
+        wrong email address.
+      {% endblocktrans %}
+    </p>
+  </div>
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_right_buttons %}
   {% if request.user|is_admin:object %}

--- a/readthedocsext/theme/templates/organizations/partials/owners_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/owners_list.html
@@ -38,16 +38,10 @@
 {% endblock %}
 
 {% block list_placeholder_icon_class %}fad fa-user-plus icon{% endblock %}
+{# This placeholder content should never be visible, there should always be one owner #}
 {% block list_placeholder_header %}
-  {% blocktrans trimmed %}
-    No organization owners found or no matches found for your filter criteria.
-  {% endblocktrans %}
+  {% trans "This organization has no owner users" %}
 {% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
-  {% if request.user|is_admin:organization %}
-    <div class="ui primary button">{% trans "Invite an organization owner" %}</div>
-  {% endif %}
-{% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
   {% if request.user|is_admin:organization %}

--- a/readthedocsext/theme/templates/organizations/partials/team_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/team_list.html
@@ -27,9 +27,9 @@
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
   {% if request.user|is_admin:organization %}
-    <div href="{% url "organization_team_add" organization.slug  %}" class="ui primary button">
+    <a href="{% url "organization_team_add" organization.slug  %}" class="ui primary button">
       {% trans "Add team" %}
-    </div>
+    </a>
   {% endif %}
 {% endblock list_placeholder_text_empty %}
 

--- a/readthedocsext/theme/templates/organizations/partials/team_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/team_list.html
@@ -19,16 +19,19 @@
 {% endblock %}
 
 {% block list_placeholder_icon_class %}fad fa-users icon{% endblock %}
-{% block list_placeholder_header %}
-  {% blocktrans trimmed %}
-    No teams match your filter criteria.
-  {% endblocktrans %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching teams found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
+  {% trans "No teams are configured for this organization yet" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
   {% if request.user|is_admin:organization %}
-    <div class="ui primary button">{% trans "Create a new team" %}</div>
+    <div href="{% url "organization_team_add" organization.slug  %}" class="ui primary button">
+      {% trans "Add team" %}
+    </div>
   {% endif %}
-{% endblock list_placeholder_text %}
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_right_buttons %}
   {% if request.user|is_admin:organization %}

--- a/readthedocsext/theme/templates/organizations/partials/team_member_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/team_member_list.html
@@ -26,16 +26,20 @@
 {% endblock %}
 
 {% block list_placeholder_icon_class %}fad fa-user-plus icon{% endblock %}
-{% block list_placeholder_header %}
-  {% blocktrans trimmed %}
-    No team members match your filter criteria.
-  {% endblocktrans %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching team members found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
+  {% trans "Team has no members" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
   {% if request.user|is_admin:organization %}
-    <div class="ui primary button">{% trans "Invite member" %}</div>
+    {% url "organization_team_member_add" organization.slug team.slug as create_url %}
+    <a href="{{ create_url }}" class="ui primary button">
+      {% trans "Invite member" %}
+    </a>
   {% endif %}
-{% endblock list_placeholder_text %}
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_right_buttons %}
 {% endblock list_item_right_buttons %}

--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -26,7 +26,7 @@
   {% trans "You don't have any projects configured yet" %}
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
-  <a href="https://docs.readthedocs.io/pages/tutorial/index.html" class="ui primary button">
+  <a href="https://docs.readthedocs.io/page/tutorial/" class="ui primary button">
     {% trans "Learn how to get started" %}
   </a>
 {% endblock list_placeholder_text_empty %}

--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -19,12 +19,17 @@
 {% endblock %}
 
 {% block list_placeholder_icon_class %}{% endblock %}
-{% block list_placeholder_header %}
-  {% trans "There are no projects configured yet, or no projects match your filter criteria" %}
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
-  <div class="ui primary button">{% trans "Add a project" %}</div>
-{% endblock list_placeholder_text %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching projects found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
+  {% trans "You don't have any projects configured yet" %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
+  <a href="https://docs.readthedocs.io/pages/tutorial/index.html" class="ui primary button">
+    {% trans "Learn how to get started" %}
+  </a>
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_start %}
   <tr data-bind="using: ProjectListItemView({id: {{ object.id }}, url: '{% url "project-detail" object.pk %}'})">


### PR DESCRIPTION
- Split up placeholder content into onboarding when no objects exist
  yet, and some copy for when there are objects but they are just all
  filtered out
- Fix placeholder buttons that were not linking anywhere
- Guide away from organization creation a little. See https://github.com/readthedocs/readthedocs.org/issues/11356

----

- Fixes: #230