### PR TITLE
Projects: disable elipsis when user doesn't have permissions

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -59,7 +59,12 @@
           </a>
         </div>
       </button>
+    {% else %}
+      <button class="ui disabled dropdown button">
+        <i class="fa-solid fa-ellipsis icon"></i>
+      </button>
     {% endif %}
+
   </div>
 {% endblock list_item_right_menu %}
 


### PR DESCRIPTION
Show the elipsis as disabled when the user doesn't have permissions. Follows the same pattern with the documentation/book icon that is disabled when there is no successful build yet.

### Previously

![Screenshot_2024-06-05_16-06-53](https://github.com/readthedocs/ext-theme/assets/244656/48231485-38c7-4f94-8f16-269f020cab87)


### New behavior

![Screenshot_2024-06-05_16-17-29](https://github.com/readthedocs/ext-theme/assets/244656/8ca459ff-b197-4d04-b8e8-2efe57f67e0f)
