### PR TITLE
Traffic: show 200 and 404 pages

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
@@ -18,6 +18,8 @@
 {% block top_menu %}
   {% if not enabled %}
     {% include "organizations/includes/feature_disabled.html" with project=project %}
+  {% else %}
+    {{ block.super }}
   {% endif %}
 {% endblock top_menu %}
 
@@ -25,7 +27,11 @@
 {% endblock top_left_menu_items %}
 
 {% block create_button %}
-{% endblock %}
+  <a class="ui button" href="?download=true">
+    <i class="fa-duotone fa-download icon"></i>
+    {% trans "Download traffic data" %}
+  </a>
+{% endblock create_button %}
 
 {% block list_placeholder_icon_class %}fa-duotone fa-chart-mixed{% endblock %}
 {% block list_placeholder_header %}
@@ -48,13 +54,13 @@
 {% block list_item_right_menu %}
   <div class="ui right floated text menu">
     <div class="item">
-      {{ count.1 }}
+      {{ object.2 }}
     </div>
   </div>
 {% endblock list_item_right_menu %}
 
 {% block list_item_header %}
-  {{ object.0 }}
+  <a href="{{ object.1}}">{{ object.0 }}</a>
 {% endblock list_item_header %}
 
 {% block list_item_meta %}

--- a/readthedocsext/theme/templates/projects/traffic_analytics.html
+++ b/readthedocsext/theme/templates/projects/traffic_analytics.html
@@ -10,7 +10,7 @@
 {% block project_edit_content %}
   <div data-bind="using: ProjectTrafficAnalyticsView()">
 
-    {% include "projects/partials/edit/traffic_list.html" with objects=top_viewed_pages %}
+    {% include "projects/partials/edit/traffic_list.html" with objects=top_pages_200 %}
 
     <h3 class="ui small header">
       {% trans "Overview" %}
@@ -50,6 +50,15 @@
         }
       </script>
     </div>
+
+    <h3 class="ui small header">
+      {% trans "Not found pages (404)" %}
+      <div class="sub header">
+        {% trans "For the last month" %}
+      </div>
+    </h3>
+    {% include "projects/partials/edit/traffic_list.html" with objects=top_pages_404 %}
+
   </div>
 {% endblock %}
 


### PR DESCRIPTION
This PR makes the minimal changes to show the data when it's available. There may be some tweaks and styles we want to improve, but I focus on making the data to be shown first. We can come back later and improve it in a second iteration.

![Screenshot 2024-06-05 at 18-40-37 Traffic Analytics - Read the Docs](https://github.com/readthedocs/ext-theme/assets/244656/474e6abc-c4df-41af-acb5-481f42aaed0f)


Closes #349