### PR TITLE
Fix distribution not including some templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-graft readthedocsext/theme/static/
-graft readthedocsext/theme/templates/
+recursive-include readthedocsext/theme/static *
+recursive-include readthedocsext/theme/templates *


### PR DESCRIPTION
For some weird reason, graft isn't including some directories in the final distribution (organizations/settings for example). Using recursive-include fixes that problem,
not sure if this is a bug with setuptools or something else.