### PR TITLE
Remove comments from examples when adding projects

### DIFF
--- a/readthedocsext/theme/templates/projects/import_config.html
+++ b/readthedocsext/theme/templates/projects/import_config.html
@@ -55,19 +55,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
-# Optionally build your docs in additional formats such as PDF and ePub
-# formats:
-#    - pdf
-#    - epub
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
@@ -101,10 +92,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
 
 # Build documentation with Mkdocs
 mkdocs:
@@ -142,10 +129,6 @@ build:
   os: ubuntu-22.04
   tools:
     nodejs: "19"
-    # You can also specify other tool versions:
-    # python: "3.12"
-    # rust: "1.64"
-    # golang: "1.19"
 
   commands:
     # Install Docusaurus dependencies
@@ -181,10 +164,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
 
   commands:
     # Install Pelican and its dependencies
@@ -217,11 +196,6 @@ build:
   os: ubuntu-22.04
   tools:
     ruby: "3.3"
-    # You can also specify other tool versions:
-    # python: "3.12"
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
 
   commands:
     # Install dependencies


### PR DESCRIPTION
I removed all the other `build.tools` that are not related with the current example.

The only thing that I didn't remove yet is the part that talks about pinning the dependencies because I think most users will require that anyways.

Related https://github.com/readthedocs/ext-theme/issues/373