### PR TITLE
Support: expose our email in case the form fails

### DIFF
--- a/readthedocsext/theme/templates/support/error.html
+++ b/readthedocsext/theme/templates/support/error.html
@@ -14,6 +14,7 @@
     <span>
       {% blocktrans trimmed %}
         Please try again, filling out all form fields.
+        If the problem persists, contact us via email at <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a>.
       {% endblocktrans %}
     </span>
   </div>


### PR DESCRIPTION
Tell people to contact us via email if the form fails for any reason.

Closes https://github.com/readthedocs/readthedocs.org/issues/8314