### PR TITLE
Use sign up instead of sign in when signing up

### DIFF
--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -27,7 +27,7 @@
         data-bind="semanticui: {tabs: {history: true, autoTabActivation: false}}">
 
         <div class="header item">
-          {% trans "Log in using:" %}
+          {% block authentication_header_text %}{% trans "Log in using:" %}{% endblock %}
         </div>
 
         <a class="item" data-tab="vcs">

--- a/readthedocsext/theme/templates/account/signup.html
+++ b/readthedocsext/theme/templates/account/signup.html
@@ -12,6 +12,7 @@
 
 {% block authentication_vcs_text %}{% trans "Connect account" %}{% endblock %}
 {% block authentication_email_text %}{% trans "Sign up with email" %}{% endblock %}
+{% block authentication_header_text %}{% trans "Sing up using:" %}{% endblock %}
 
 {% block authentication_vcs %}
   {# Translators: this will read "Sign up using GitHub", where "sign up" is a verb #}

--- a/readthedocsext/theme/templates/account/signup.html
+++ b/readthedocsext/theme/templates/account/signup.html
@@ -14,8 +14,8 @@
 {% block authentication_email_text %}{% trans "Sign up with email" %}{% endblock %}
 
 {% block authentication_vcs %}
-  {# Translators: this will read "Log in with GitHub", where "log in" is a verb #}
-  {% blocktrans asvar text_log_in %}Log in using{% endblocktrans %}
+  {# Translators: this will read "Sign up using GitHub", where "sign up" is a verb #}
+  {% blocktrans asvar text_log_in %}Sign up using{% endblocktrans %}
   {% include "socialaccount/snippets/provider_list.html" with process="login" verbiage=text_log_in %}
 {% endblock authentication_vcs %}
 


### PR DESCRIPTION
Currently this reads "Sign in" when the user is signing up. I'm guessing this was a mistake.

The sign in page still says "Sign in with".

![Screenshot 2024-06-20 at 11-45-34 Sign up - Read the Docs](https://github.com/readthedocs/ext-theme/assets/4975310/fe9ba21a-0fa2-45ac-872c-a54866d6b049)
