### PR TITLE
Help topics on base dashboard

### DIFF
--- a/readthedocsext/theme/templates/projects/base_dashboard.html
+++ b/readthedocsext/theme/templates/projects/base_dashboard.html
@@ -36,31 +36,26 @@
           {% include promotion %}
         {% endif %}
 
-        <div class="basic card">
-          <div class="content">
-            <a class="header" href="https://docs.readthedocs.io/en/stable/">
-              {% trans "Learn more" %}
-            </a>
-            <div class="meta">{% trans "Some resources from our documentation" %}</div>
-            <div class="description">
-              <div class="ui mini header">{% trans "Tutorials" %}</div>
-              <div class="ui bulleted list">
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Getting started" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" text="Getting started with Sphinx" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-mkdocs.html" text="Getting started with MkDocs" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Creating a project" is_external=True class="item" %}
-              </div>
+        <div class="ui basic segment">
+          <h2 class="ui small header">
+            {% trans "Help topics" %}
+          </h2>
+          <div class="ui mini header">{% trans "Tutorials" %}</div>
+          <div class="ui bulleted list">
+            {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Getting started" is_external=True class="item" %}
+            {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" text="Getting started with Sphinx" is_external=True class="item" %}
+            {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/getting-started-with-mkdocs.html" text="Getting started with MkDocs" is_external=True class="item" %}
+            {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Creating a project" is_external=True class="item" %}
+          </div>
 
-              <div class="ui mini header">{% trans "Reference" %}</div>
-              <div class="ui bulleted list">
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/index.html" text="Configuration file reference" is_external=True class="item" %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/build-customization.html" text="Build process customization" is_external=True class="item" %}
-              </div>
-            </div>
+          <div class="ui mini header">{% trans "Reference" %}</div>
+          <div class="ui bulleted list">
+            {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/index.html" text="Configuration file reference" is_external=True class="item" %}
+            {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/build-customization.html" text="Build process customization" is_external=True class="item" %}
           </div>
         </div>
-
       </div>
     </div>
+
   </div>
 {% endblock content %}


### PR DESCRIPTION
This PR copies the same pattern we have in other places (eg. project's settings) using "Help topics". I copied it from there because it renders nicer than the one we had and also to keep consistency between them all.