### PR TITLE
Build popups: simplification

### DIFF
--- a/readthedocsext/theme/templates/builds/partials/version_list.html
+++ b/readthedocsext/theme/templates/builds/partials/version_list.html
@@ -183,7 +183,7 @@
   {% with build=object.last_build %}
     {% if build %}
       <div class="item">
-        {% include "includes/elements/chips/build.html" with build=build text=object.project.name %}
+        {% include "includes/elements/chips/build.html" with build=build notext=True %}
       </div>
     {% endif %}
   {% endwith %}

--- a/readthedocsext/theme/templates/includes/elements/chips/build.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/build.html
@@ -55,7 +55,7 @@
   {% if build.commit %}
     <span>
       <i class="fad fa-code-commit icon"></i>
-      {{ build.commit|slice:"0:8" }}
+      <a href="{{ build.get_commit_url }}">{{ build.commit|slice:"0:8" }}</a>
     </span>
   {% endif %}
   <div class="right floated">

--- a/readthedocsext/theme/templates/includes/elements/chips/build.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/build.html
@@ -19,7 +19,9 @@
     instance was deleted at some point. The version name is stored on the build
     in this scenario.
   {% endcomment %}
-  {% firstof text build.get_version_name %}
+  {% if not notext %}
+    {% firstof text build.get_version_name %}
+  {% endif %}
 {% endblock chip_text %}
 
 {% block chip_detail_text %}
@@ -30,7 +32,7 @@
   {% comment %}
     This block is the same as the chip_text block above.
   {% endcomment %}
-  {% firstof text build.get_version_name %} #{{ build.id }}
+  Build <a href="{% url 'builds_detail' build.project.slug build.pk %}">#{{ build.id }}</a>
 {% endblock popupcard_header %}
 
 {% block popupcard_right %}


### PR DESCRIPTION
This commit simplifies the build chip a little:

- removes the `text` for the list item since it always repeat the name of the project and there is no need to show it so many times
- removes the name of the project from the popup title for the same reason
- adds the text "Build" to the title since it conveys a more clear meaning
- makes the build number clickable, so we can go to the build details page from the chip's title
- adds a link to the commit URL

|Old|New|
|--- | --- |
| ![Screenshot_2024-07-04_13-58-38](https://github.com/readthedocs/ext-theme/assets/244656/db64ade9-5b78-41cc-99fc-023a0d37de8e) | ![Screenshot_2024-07-04_13-58-02](https://github.com/readthedocs/ext-theme/assets/244656/555a67db-6296-4974-8d36-59c9006601ee) |
| ![Screenshot_2024-07-04_13-58-29](https://github.com/readthedocs/ext-theme/assets/244656/edf4f121-215c-44de-9bff-113b412f5d11) | ![Screenshot_2024-07-04_13-57-53](https://github.com/readthedocs/ext-theme/assets/244656/2e4f8618-b90c-4457-90c0-8f3bcd501463) |


