### PR TITLE
Project: use a custom template filter to avoid zh languages

### DIFF
--- a/readthedocsext/theme/templates/includes/elements/chips/project.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/project.html
@@ -8,7 +8,9 @@
   '{% url "projects-detail" project.slug %}'
 {% endblock chip_view_params %}
 
-{% block chip_url %}{{ project.get_absolute_url }}{% endblock %}
+{% block chip_url %}
+  {{ project.get_absolute_url }}
+{% endblock chip_url %}
 
 {% block chip_classes %}
   basic image
@@ -16,7 +18,7 @@
 
 {% block chip_icon %}
   {% if project.remote_repository %}
-    <img src="{{ project.remote_repository.avatar_url }}" />
+    <img alt="Project avatar" src="{{ project.remote_repository.avatar_url }}" />
   {% else %}
     {% comment %}
       For now, this is using Dicebear, which has a few random generators for
@@ -24,7 +26,8 @@
       similar to generate files on disk and use an md5 hash or similar to link
       to the same image always.
     {% endcomment %}
-    <img src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
+    <img alt="Project avatar"
+         src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
   {% endif %}
 {% endblock chip_icon %}
 
@@ -45,7 +48,8 @@
 
 {% block popupcard_right %}
   {% if project.remote_repository %}
-    <img class="ui mini right floated rounded image"
+    <img alt="Project avatar"
+         class="ui mini right floated rounded image"
          src="{{ project.remote_repository.avatar_url }}" />
   {% else %}
     {% comment %}
@@ -54,7 +58,8 @@
       similar to generate files on disk and use an md5 hash or similar to link
       to the same image always.
     {% endcomment %}
-    <img class="ui mini right floated rounded image"
+    <img alt="Project avatar"
+         class="ui mini right floated rounded image"
          src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
   {% endif %}
 {% endblock popupcard_right %}

--- a/readthedocsext/theme/templates/includes/elements/chips/project.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/project.html
@@ -18,7 +18,8 @@
 
 {% block chip_icon %}
   {% if project.remote_repository %}
-    <img alt="Project avatar" src="{{ project.remote_repository.avatar_url }}" />
+    <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
+         src="{{ project.remote_repository.avatar_url }}" />
   {% else %}
     {% comment %}
       For now, this is using Dicebear, which has a few random generators for
@@ -26,7 +27,7 @@
       similar to generate files on disk and use an md5 hash or similar to link
       to the same image always.
     {% endcomment %}
-    <img alt="Project avatar"
+    <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
          src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
   {% endif %}
 {% endblock chip_icon %}
@@ -48,7 +49,7 @@
 
 {% block popupcard_right %}
   {% if project.remote_repository %}
-    <img alt="Project avatar"
+    <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
          class="ui mini right floated rounded image"
          src="{{ project.remote_repository.avatar_url }}" />
   {% else %}
@@ -58,7 +59,7 @@
       similar to generate files on disk and use an md5 hash or similar to link
       to the same image always.
     {% endcomment %}
-    <img alt="Project avatar"
+    <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
          class="ui mini right floated rounded image"
          src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
   {% endif %}

--- a/readthedocsext/theme/templates/includes/elements/chips/project.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/project.html
@@ -4,11 +4,11 @@
 {% load humanize %}
 {% load ext_theme_tags %}
 
-{% block chip_view_params %}'{% url "projects-detail" project.slug %}'{% endblock %}
+{% block chip_view_params %}
+  '{% url "projects-detail" project.slug %}'
+{% endblock chip_view_params %}
 
-{% block chip_url %}
-  {{ project.get_absolute_url }}
-{% endblock %}
+{% block chip_url %}{{ project.get_absolute_url }}{% endblock %}
 
 {% block chip_classes %}
   basic image
@@ -45,7 +45,8 @@
 
 {% block popupcard_right %}
   {% if project.remote_repository %}
-    <img class="ui mini right floated rounded image" src="{{ project.remote_repository.avatar_url }}" />
+    <img class="ui mini right floated rounded image"
+         src="{{ project.remote_repository.avatar_url }}" />
   {% else %}
     {% comment %}
       For now, this is using Dicebear, which has a few random generators for
@@ -53,7 +54,8 @@
       similar to generate files on disk and use an md5 hash or similar to link
       to the same image always.
     {% endcomment %}
-    <img class="ui mini right floated rounded image" src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
+    <img class="ui mini right floated rounded image"
+         src="https://api.dicebear.com/5.x/shapes/svg?size=64&backgroundColor=b8abd4&shape1Color=8c74c1&shape2Color=7854c5&shape3Color=f0f0ff&seed={{ project.pk }}" />
   {% endif %}
 {% endblock popupcard_right %}
 
@@ -71,15 +73,9 @@
         <div class="header">{% trans "Repository" %}</div>
         <div class="description">
           {% if project.remote_repository %}
-            {% with repo=project.remote_repository %}
-              <a href="{{ repo.html_url }}">
-                {{ repo.full_name }}
-              </a>
-            {% endwith %}
+            {% with repo=project.remote_repository %}<a href="{{ repo.html_url }}">{{ repo.full_name }}</a>{% endwith %}
           {% else %}
-            <a href="{{ project.repo }}">
-              {{ project.repo }}
-            </a>
+            <a href="{{ project.repo }}">{{ project.repo }}</a>
           {% endif %}
         </div>
       </div>

--- a/readthedocsext/theme/templates/includes/elements/chips/project.html
+++ b/readthedocsext/theme/templates/includes/elements/chips/project.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load humanize %}
+{% load ext_theme_tags %}
 
 {% block chip_view_params %}'{% url "projects-detail" project.slug %}'{% endblock %}
 
@@ -106,6 +107,6 @@
   </div>
   <span>
     <i class="fa-solid fa-language icon"></i>
-    {{ project.language|language_name }}
+    {{ project.language|readthedocs_language_name }}
   </span>
 {% endblock popupcard_extra %}

--- a/readthedocsext/theme/templates/includes/footer.html
+++ b/readthedocsext/theme/templates/includes/footer.html
@@ -85,20 +85,20 @@
           <div class="left aligned item">
             <i class="large fa-duotone fa-code-branch icon"></i>
             <div class="content">
-              <div class="header">{% trans 'Version' %}</div>
+              <div class="header">{% trans "Version" %}</div>
               <div class="description">
-                <a href="http://docs.readthedocs.io/page/changelog.html">{% readthedocs_version %}</a>
+                <a href="https://docs.readthedocs.io/page/changelog.html">{% readthedocs_version %}</a>
               </div>
             </div>
           </div>
           <div class="left aligned item">
             <i class="large fa-duotone fa-language icon"></i>
             <div class="content">
-              <div class="header">{% trans 'Language' %}</div>
+              <div class="header">{% trans "Language" %}</div>
               <div class="description">
                 {% block language_select_form %}
                   {% get_current_language as current_lang %}
-                  <form action="/i18n/setlang/" method="post">
+                  <form action="{% url 'set_language' %}" method="post">
                     <div class="field">
                       <input name="next" type="hidden" value="/" />
                     </div>

--- a/readthedocsext/theme/templates/includes/footer.html
+++ b/readthedocsext/theme/templates/includes/footer.html
@@ -14,12 +14,19 @@
             {% block menu_news %}
               <h4 class="ui inverted sub header">Stay updated</h4>
               <a class="item" href="https://about.readthedocs.com/blog/">Blog</a>
-              <a class="item" href="https://landing.mailerlite.com/webforms/landing/t0a9l4">Newsletter</a>
+              <a class="item"
+                 href="https://landing.mailerlite.com/webforms/landing/t0a9l4">Newsletter</a>
               <a class="item" href="https://status.readthedocs.com/">Status</a>
               <div class="item">
-                <a href="https://github.com/readthedocs/" aria-label="Read the Docs on GitHub" rel="noopener noreferrer"><i class="icon large fab fa-github"></i></a>
-                <a href="https://twitter.com/readthedocs" aria-label="Read the Docs on Twitter" rel="noopener noreferrer"><i class="icon large fab fa-twitter"></i></a>
-                <a href="https://fosstodon.org/@readthedocs" aria-label="Read the Docs on Mastodon / Fediverse" rel="me"><i class="icon large fab fa-mastodon"></i></a>
+                <a href="https://github.com/readthedocs/"
+                   aria-label="Read the Docs on GitHub"
+                   rel="noopener noreferrer"><i class="icon large fab fa-github"></i></a>
+                <a href="https://twitter.com/readthedocs"
+                   aria-label="Read the Docs on Twitter"
+                   rel="noopener noreferrer"><i class="icon large fab fa-twitter"></i></a>
+                <a href="https://fosstodon.org/@readthedocs"
+                   aria-label="Read the Docs on Mastodon / Fediverse"
+                   rel="me"><i class="icon large fab fa-mastodon"></i></a>
               </div>
             {% endblock menu_news %}
           </div>
@@ -30,7 +37,8 @@
             {% block menu_learn %}
               <h4 class="ui inverted sub header">Learn more</h4>
               <a class="item" href="https://docs.readthedocs.io">Documentation</a>
-              <a class="item" href="https://docs.readthedocs.io/page/tutorial/index.html">Getting started guide</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/tutorial/index.html">Getting started guide</a>
               <a class="item" href="https://docs.readthedocs.io/page/config-file/">Configure your project</a>
             {% endblock menu_learn %}
           </div>
@@ -43,8 +51,10 @@
               <a class="item" href="https://about.readthedocs.com/pricing/">Pricing</a>
               <a class="item" href="https://about.readthedocs.com/features/">Features</a>
               <a class="item" href="https://www.ethicalads.io/advertisers/?ref=rtd">Advertise with Us</a>
-              <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
-              <a class="item" href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>
             {% endblock menu_services %}
           </div>
         </div>
@@ -77,9 +87,7 @@
             <div class="content">
               <div class="header">{% trans 'Version' %}</div>
               <div class="description">
-                <a href="http://docs.readthedocs.io/page/changelog.html">
-                  {% readthedocs_version %}
-                </a>
+                <a href="http://docs.readthedocs.io/page/changelog.html">{% readthedocs_version %}</a>
               </div>
             </div>
           </div>
@@ -95,7 +103,8 @@
                       <input name="next" type="hidden" value="/" />
                     </div>
                     {% csrf_token %}
-                    <div class="ui very wide search dropdown" data-bind="semanticui: { dropdown: {direction: 'upward', fullTextSearch: true, cache: false}}">
+                    <div class="ui very wide search dropdown"
+                         data-bind="semanticui: { dropdown: {direction: 'upward', fullTextSearch: true, cache: false}}">
                       <input type="hidden" name="language" />
                       <span class="default text">{{ current_lang | readthedocs_language_name_local }}</span>
                       <i class="fa-solid fa-caret-down icon"></i>
@@ -106,7 +115,9 @@
                         </div>
                         <div class="divider"></div>
                         {% for lang in LANGUAGES %}
-                          <div class="vertical item {% if lang.0 == current_lang %}active{% endif %}" data-value="{{ lang.0 }}" data-text="{{ lang.0 | readthedocs_language_name_local }}">
+                          <div class="vertical item {% if lang.0 == current_lang %}active{% endif %}"
+                               data-value="{{ lang.0 }}"
+                               data-text="{{ lang.0 | readthedocs_language_name_local }}">
                             <div class="description">{{ lang.0 | readthedocs_language_name_translated }}</div>
                             <div class="text">{{ lang.0 | readthedocs_language_name_local }}</div>
                           </div>
@@ -114,9 +125,7 @@
                       </div>
                     </div>
                     {# TODO this button would be better off as a onChange event #}
-                    <button class="ui tiny compact basic inverted button">
-                      {% trans "Update" %}
-                    </button>
+                    <button class="ui tiny compact basic inverted button">{% trans "Update" %}</button>
                   </form>
                 {% endblock language_select_form %}
               </div>
@@ -136,15 +145,15 @@
     {% block footer_sponsors %}
       {% if USE_PROMOS %}
 
-        <div class="ui inverted horizontal divider very padded">
-          Sponsored by
-        </div>
+        <div class="ui inverted horizontal divider very padded">Sponsored by</div>
 
         <div class="ui six column doubling grid container">
           <div class="column bottom aligned centered">
             <div class="ui tiny inverted header centered">
               <a href="https://aws.amazon.com" rel="noopener" target="_blank">
-                <img class="ui tiny centered image" src="{% static 'images/sponsors/aws.png' %}" alt="Amazon Web Services" />
+                <img class="ui tiny centered image"
+                     src="{% static 'images/sponsors/aws.png' %}"
+                     alt="Amazon Web Services" />
                 AWS
                 <div class="sub header">Cloud Computing</div>
               </a>
@@ -153,7 +162,9 @@
           <div class="column bottom aligned centered">
             <div class="ui tiny inverted header centered">
               <a href="https://cloudflare.com" rel="noopener" target="_blank">
-                <img class="ui tiny centered image" src="{% static 'images/sponsors/cloudflare.png' %}" alt="CloudFlare">
+                <img class="ui tiny centered image"
+                     src="{% static 'images/sponsors/cloudflare.png' %}"
+                     alt="CloudFlare">
                 Cloudflare
                 <div class="sub header">DNS &amp; SSL</div>
               </a>
@@ -162,7 +173,9 @@
           <div class="column bottom aligned centered">
             <div class="ui tiny inverted header centered">
               <a href="https://sentry.io/" rel="noopener" target="_blank">
-                <img class="ui tiny centered image" src="{% static 'images/sponsors/sentry.png' %}" alt="Sentry">
+                <img class="ui tiny centered image"
+                     src="{% static 'images/sponsors/sentry.png' %}"
+                     alt="Sentry">
                 Sentry
                 <div class="sub header">Monitoring</div>
               </a>
@@ -171,7 +184,9 @@
           <div class="column bottom aligned centered">
             <div class="ui tiny inverted header centered">
               <a href="https://www.elastic.co/" rel="noopener" target="_blank">
-                <img class="ui tiny centered image" src="{% static 'images/sponsors/elastic.png' %}" alt="Elastic">
+                <img class="ui tiny centered image"
+                     src="{% static 'images/sponsors/elastic.png' %}"
+                     alt="Elastic">
                 Elastic
                 <div class="sub header">Search</div>
               </a>
@@ -180,7 +195,9 @@
           <div class="column bottom aligned centered">
             <div class="ui tiny inverted header centered">
               <a href="https://newrelic.com/" rel="noopener" target="_blank">
-                <img class="ui tiny centered image" src="{% static 'images/sponsors/newrelic.png' %}" alt="New Relic">
+                <img class="ui tiny centered image"
+                     src="{% static 'images/sponsors/newrelic.png' %}"
+                     alt="New Relic">
                 New Relic
                 <div class="sub header">Performance</div>
               </a>
@@ -189,7 +206,9 @@
           <div class="column bottom aligned centered">
             <div class="ui tiny inverted header centered">
               <a href="https://www.pagerduty.com/" rel="noopener" target="_blank">
-                <img class="ui tiny centered image" src="{% static 'images/sponsors/pagerduty.png' %}" alt="PagerDuty">
+                <img class="ui tiny centered image"
+                     src="{% static 'images/sponsors/pagerduty.png' %}"
+                     alt="PagerDuty">
                 PagerDuty
                 <div class="sub header">Monitoring</div>
               </a>

--- a/readthedocsext/theme/templates/includes/footer.html
+++ b/readthedocsext/theme/templates/includes/footer.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load core_tags %}
 {% load static %}
+{% load ext_theme_tags %}
 
 <footer class="ui basic very padded inverted attached segment">
   <div class="ui container">
@@ -96,7 +97,7 @@
                     {% csrf_token %}
                     <div class="ui very wide search dropdown" data-bind="semanticui: { dropdown: {direction: 'upward', fullTextSearch: true, cache: false}}">
                       <input type="hidden" name="language" />
-                      <span class="default text">{{ current_lang | language_name_local }}</span>
+                      <span class="default text">{{ current_lang | readthedocs_language_name_local }}</span>
                       <i class="fa-solid fa-caret-down icon"></i>
                       <div class="menu">
                         <div class="ui icon search input">
@@ -105,9 +106,9 @@
                         </div>
                         <div class="divider"></div>
                         {% for lang in LANGUAGES %}
-                          <div class="vertical item {% if lang.0 == current_lang %}active{% endif %}" data-value="{{ lang.0 }}" data-text="{{ lang.0 | language_name_local }}">
-                            <div class="description">{{ lang.0 | language_name_translated }}</div>
-                            <div class="text">{{ lang.0 | language_name_local }}</div>
+                          <div class="vertical item {% if lang.0 == current_lang %}active{% endif %}" data-value="{{ lang.0 }}" data-text="{{ lang.0 | readthedocs_language_name_local }}">
+                            <div class="description">{{ lang.0 | readthedocs_language_name_translated }}</div>
+                            <div class="text">{{ lang.0 | readthedocs_language_name_local }}</div>
                           </div>
                         {% endfor %}
                       </div>

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -119,7 +119,7 @@ collapsed, to save visual space and can be expanded with the right label.
               <div class="ui overlapping avatar images">
                 {% for user in project.users.all|slice:":8" %}
                   <a href="{% url "profiles_profile_detail" user.username %}">
-                    <img alt="User avatar"
+                    <img alt="{% blocktrans with usernamename=user.username %}User {{ username }} avatar{% endblocktrans %}"
                          class="ui image"
                          src="{% gravatar_url user.email 32 %}" />
                   </a>
@@ -140,7 +140,8 @@ collapsed, to save visual space and can be expanded with the right label.
               {% if project.remote_repository %}
                 {% with repo=project.remote_repository %}
                   <a href="{{ repo.html_url }}" class="ui basic image nowrap label">
-                    <img alt="Project avatar" src="{{ repo.avatar_url }}" />
+                    <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
+                         src="{{ repo.avatar_url }}" />
                     <code>{{ repo.full_name }}</code>
                   </a>
                 {% endwith %}

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -14,7 +14,8 @@ collapsed, to save visual space and can be expanded with the right label.
 {% endcomment %}
 
 {% block project_header %}
-  <div class="ui top attached segment" data-bind="using: CollapsingHeaderView(true)">
+  <div class="ui top attached segment"
+       data-bind="using: CollapsingHeaderView(true)">
 
     {% block project_header_metadata %}
       <div class="ui stacking grid">
@@ -22,9 +23,7 @@ collapsed, to save visual space and can be expanded with the right label.
         {% block project_header_title %}
           <div class="eight wide computer eight wide tablet sixteen wide mobile middle aligned column">
             {% include "projects/includes/project_image.html" with project=project classes="micro rounded right spaced inline" %}
-            <a class="ui medium text" href="{{ project.get_absolute_url }}">
-              {{ project.name | default:project.slug }}
-            </a>
+            <a class="ui medium text" href="{{ project.get_absolute_url }}">{{ project.name | default:project.slug }}</a>
           </div>
         {% endblock project_header_title %}
 
@@ -36,35 +35,34 @@ collapsed, to save visual space and can be expanded with the right label.
             {% endfor %}
 
             {# The dropdown action button, to swap between expanded/collapsed #}
-            <a class="ui icon primary label" data-bind="click: toggle_collapsed" data-content="{% trans "More project information" %}">
+            <a class="ui icon primary label"
+               data-bind="click: toggle_collapsed"
+               data-content="{% trans "More project information" %}">
               <i class="fas fa-caret-down icon" data-bind="class: dropdown_class"></i>
             </a>
           </div>
         {% endblock project_header_labels %}
 
         {% block project_header_metadata_left %}
-          <div class="eight wide computer eight wide tablet sixteen wide mobile column" data-bind="visible: !is_collapsed()" style="display: none;">
+          <div class="eight wide computer eight wide tablet sixteen wide mobile column"
+               data-bind="visible: !is_collapsed()"
+               style="display: none">
 
             {% block project_header_description %}
-              {% if project.description %}
-                <p>
-                  {{ project.description|truncatewords:15 }}
-                </p>
-              {% endif %}
+              {% if project.description %}<p>{{ project.description|truncatewords:15 }}</p>{% endif %}
             {% endblock %}
 
             {% block project_header_tags %}
               {# Manual tags #}
               {% for tag in project.tags.all %}
-                <a class="ui teal basic label" href="{% url "projects_tag_detail" tag.slug %}">{{ tag.name }}</a>
+                <a class="ui teal basic label"
+                   href="{% url "projects_tag_detail" tag.slug %}">{{ tag.name }}</a>
               {% endfor %}
             {% endblock project_header_tags %}
 
             {% block project_header_related_projects %}
               {% if project.superproject or project.subprojects.exists %}
-                <div class="ui sub header">
-                  {% trans "Related projects" %}
-                </div>
+                <div class="ui sub header">{% trans "Related projects" %}</div>
                 <div class="ui relaxed horizontal list">
                   {% if project.superproject %}
                     <div class="item">
@@ -84,9 +82,7 @@ collapsed, to save visual space and can be expanded with the right label.
             {% block project_header_translations %}
               {% with translations=project.main_language_project.translations|default:project.translations %}
                 {% if translations.exists %}
-                  <div class="ui sub header">
-                    {% trans "Translations" %}
-                  </div>
+                  <div class="ui sub header">{% trans "Translations" %}</div>
                   <div class="ui horizontal list">
                     {% with project_translation=project.main_language_project|default:project %}
                       {% if not project_translation == project %}
@@ -111,12 +107,12 @@ collapsed, to save visual space and can be expanded with the right label.
         {% endblock project_header_metadata_left %}
 
         {% block project_header_metadata_right %}
-          <div class="right aligned eight wide computer eight wide tablet sixteen wide mobile column" data-bind="visible: !is_collapsed()" style="display: none;">
+          <div class="right aligned eight wide computer eight wide tablet sixteen wide mobile column"
+               data-bind="visible: !is_collapsed()"
+               style="display: none">
 
             {% block project_header_maintainers %}
-              <div class="ui sub header">
-                {% trans "Maintainers" %}
-              </div>
+              <div class="ui sub header">{% trans "Maintainers" %}</div>
 
               {# TODO project teams and organization #}
 
@@ -129,9 +125,7 @@ collapsed, to save visual space and can be expanded with the right label.
 
                 {% with other_maintainers=project.users.all|slice:"8:"|length %}
                   {% if other_maintainers %}
-                    <span>
-                      {% trans "... and {other_maintainers} others" %}
-                    </span>
+                    <span>{% trans "... and {other_maintainers} others" %}</span>
                   {% endif %}
                 {% endwith %}
 
@@ -139,9 +133,7 @@ collapsed, to save visual space and can be expanded with the right label.
             {% endblock project_header_maintainers %}
 
             {% block project_header_repository %}
-              <div class="ui sub header">
-                {% trans "Repository" %}
-              </div>
+              <div class="ui sub header">{% trans "Repository" %}</div>
 
               {% if project.remote_repository %}
                 {% with repo=project.remote_repository %}
@@ -167,7 +159,8 @@ collapsed, to save visual space and can be expanded with the right label.
 
   {% block project_header_navigation %}
     <div class="ui bottom attached stackable menu">
-      <a class="item {{ overview_active }}" href="{{ project.get_absolute_url }}">
+      <a class="item {{ overview_active }}"
+         href="{{ project.get_absolute_url }}">
         {% trans "Versions" %}
         <span class="ui tiny teal circular label">{{ project.active_versions.count }}</span>
       </a>
@@ -183,7 +176,8 @@ collapsed, to save visual space and can be expanded with the right label.
               {% trans "Debug" %}
             </a>
           {% endif %}
-          <a class="item {{ edit_active }}" href="{% url "projects_edit" project.slug %}">
+          <a class="item {{ edit_active }}"
+             href="{% url "projects_edit" project.slug %}">
             <i class="fa-duotone fa-gears icon"></i>
             {% trans "Settings" %}
           </a>
@@ -193,9 +187,7 @@ collapsed, to save visual space and can be expanded with the right label.
 
 
     <div class="ui mini modal" data-modal-id="project-debug">
-      <div class="header">
-        {% trans "Debug information" %}
-      </div>
+      <div class="header">{% trans "Debug information" %}</div>
       {% comment %}
         Show spam information on community instance.
         Allows us to quickly understand what's the spam score,
@@ -204,21 +196,15 @@ collapsed, to save visual space and can be expanded with the right label.
       <div class="content">
         {% if not USE_ORGANIZATIONS %}
           <h3>{% trans "Spam" %}</h3>
-          <div class="ui sub header">
-            {% trans "Spam score" %}
-          </div>
-          <span>{{ project|get_spam_score }} </span>
+          <div class="ui sub header">{% trans "Spam score" %}</div>
+          <span>{{ project|get_spam_score }}</span>
           {% if project.spam_rules.exists %}
-            <div class="ui sub header">
-              {% trans "Spam matching rules" %}
-            </div>
+            <div class="ui sub header">{% trans "Spam matching rules" %}</div>
             <div class="ui vertical list">
               {% for rule in project.spam_rules.all %}
                 <div class="item">
                   <a href="{{ ADMIN_URL }}/spamfighting/spamrule/{{ rule.pk }}/change/"
-                     target="_blank">
-                    {{ rule.spam_rule_type|cut:"readthedocsext.spamfighting.rules." }}
-                  </a>
+                     target="_blank">{{ rule.spam_rule_type|cut:"readthedocsext.spamfighting.rules." }}</a>
                 </div>
               {% endfor %}
             </div>

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -50,7 +50,7 @@ collapsed, to save visual space and can be expanded with the right label.
 
             {% block project_header_description %}
               {% if project.description %}<p>{{ project.description|truncatewords:15 }}</p>{% endif %}
-            {% endblock %}
+            {% endblock project_header_description %}
 
             {% block project_header_tags %}
               {# Manual tags #}
@@ -119,7 +119,9 @@ collapsed, to save visual space and can be expanded with the right label.
               <div class="ui overlapping avatar images">
                 {% for user in project.users.all|slice:":8" %}
                   <a href="{% url "profiles_profile_detail" user.username %}">
-                    <img class="ui image" src="{% gravatar_url user.email 32 %}" />
+                    <img alt="User avatar"
+                         class="ui image"
+                         src="{% gravatar_url user.email 32 %}" />
                   </a>
                 {% endfor %}
 
@@ -138,7 +140,7 @@ collapsed, to save visual space and can be expanded with the right label.
               {% if project.remote_repository %}
                 {% with repo=project.remote_repository %}
                   <a href="{{ repo.html_url }}" class="ui basic image nowrap label">
-                    <img src="{{ repo.avatar_url }}" />
+                    <img alt="Project avatar" src="{{ repo.avatar_url }}" />
                     <code>{{ repo.full_name }}</code>
                   </a>
                 {% endwith %}
@@ -184,7 +186,6 @@ collapsed, to save visual space and can be expanded with the right label.
         </div>
       {% endif %}
     </div>
-
 
     <div class="ui mini modal" data-modal-id="project-debug">
       <div class="header">{% trans "Debug information" %}</div>

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -30,18 +30,7 @@ collapsed, to save visual space and can be expanded with the right label.
 
         {% block project_header_labels %}
           <div class="right aligned eight wide computer eight wide tablet sixteen wide left aligned mobile middle aligned column">
-              {% comment %}
-              Simple solution to not supported "zh" language code.
-
-              When `project.language="zh"` the Django `language_name_local` raises an exception and returns 500.
-              This simple solution checks for this unsupported language code and replace it by "zh-cn" (Simplified Chinese).
-              We need to decide what to do at the DB level still, but at least this approach solves the immediate issue.
-              {% endcomment %}
-            {% if project.language == "zh" %}
-              {% include "includes/components/config_label.html" with icon="fa-solid fa-language" text=project.language|upper popup="zh-cn"|language_name_local %}
-            {% else %}
-              {% include "includes/components/config_label.html" with icon="fa-solid fa-language" text=project.language|upper popup=project.language|language_name_local %}
-            {% endif %}
+            {% include "includes/components/config_label.html" with icon="fa-solid fa-language" text=project.language|upper popup=project.language|readthedocs_language_name_local %}
             {% for organization in project.organizations.all %}
               {% include "includes/components/config_label.html" with icon="fa-solid fa-building" text=organization.name url=organization.get_absolute_url %}
             {% endfor %}
@@ -102,14 +91,14 @@ collapsed, to save visual space and can be expanded with the right label.
                     {% with project_translation=project.main_language_project|default:project %}
                       {% if not project_translation == project %}
                         <div class="item">
-                          {% include "includes/elements/chips/project.html" with project=project_translation detail=project_translation.language|language_name %}
+                          {% include "includes/elements/chips/project.html" with project=project_translation detail=project_translation.language|readthedocs_language_name %}
                         </div>
                       {% endif %}
                     {% endwith %}
                     {% for project_translation in translations.all %}
                       {% if not project_translation == project %}
                         <div class="item">
-                          {% include "includes/elements/chips/project.html" with project=project_translation detail=project_translation.language|language_name %}
+                          {% include "includes/elements/chips/project.html" with project=project_translation detail=project_translation.language|readthedocs_language_name %}
                         </div>
                       {% endif %}
                     {% endfor %}

--- a/readthedocsext/theme/templatetags/ext_theme_tags.py
+++ b/readthedocsext/theme/templatetags/ext_theme_tags.py
@@ -2,6 +2,7 @@ from urllib.parse import urljoin
 
 from django import template
 from django.conf import settings
+from django.templatetags.i18n import language_name_local, language_name, language_name_translated
 from django.templatetags.static import StaticNode, PrefixNode
 from django.forms import boundfield
 
@@ -124,3 +125,27 @@ def get_spam_score(project):
         return 0
 
     return spam_score(project)
+
+
+# Simple solution to not supported "zh" language code.
+#
+# When `project.language="zh"` the Django `language_name_local` raises an exception and returns 500.
+# This simple solution checks for this unsupported language code and replace it by "zh-cn" (Simplified Chinese).
+# We need to decide what to do at the DB level still, but at least this approach solves the immediate issue.
+@register.filter
+def readthedocs_language_name(lang_code):
+    if lang_code == "zh":
+        return language_name("zh-cn")
+    return language_name(lang_code)
+
+@register.filter
+def readthedocs_language_name_translated(lang_code):
+    if lang_code == "zh":
+        return language_name_translated("zh-cn")
+    return language_name_translated(lang_code)
+
+@register.filter
+def readthedocs_language_name_local(lang_code):
+    if lang_code == "zh":
+        return language_name_local("zh-cn")
+    return language_name_local(lang_code)

--- a/readthedocsext/theme/templatetags/ext_theme_tags.py
+++ b/readthedocsext/theme/templatetags/ext_theme_tags.py
@@ -2,7 +2,11 @@ from urllib.parse import urljoin
 
 from django import template
 from django.conf import settings
-from django.templatetags.i18n import language_name_local, language_name, language_name_translated
+from django.templatetags.i18n import (
+    language_name_local,
+    language_name,
+    language_name_translated,
+)
 from django.templatetags.static import StaticNode, PrefixNode
 from django.forms import boundfield
 
@@ -138,11 +142,13 @@ def readthedocs_language_name(lang_code):
         return language_name("zh-cn")
     return language_name(lang_code)
 
+
 @register.filter
 def readthedocs_language_name_translated(lang_code):
     if lang_code == "zh":
         return language_name_translated("zh-cn")
     return language_name_translated(lang_code)
+
 
 @register.filter
 def readthedocs_language_name_local(lang_code):


### PR DESCRIPTION
We keep returning 500 on projects with `zh`.
This another interation on this fix for now.

Sentry https://read-the-docs.sentry.io/issues/5066249292/
Related #370