### PR TITLE
Add notifications block to AllAuth templates

### DIFF
--- a/readthedocsext/theme/templates/allauth/layouts/base.html
+++ b/readthedocsext/theme/templates/allauth/layouts/base.html
@@ -6,7 +6,7 @@
     {# This is overriding the normal base.html content-wrapper, #}
     {# so we need to include notifications here so they're displayed. #}
     {% block notifications %}
-      {% include "includes/utils/messages.html" %}
+      {{ block.super }}
     {% endblock notifications %}
 
     <div class="ui centered grid">

--- a/readthedocsext/theme/templates/allauth/layouts/base.html
+++ b/readthedocsext/theme/templates/allauth/layouts/base.html
@@ -3,6 +3,8 @@
 {% block content-wrapper %}
   <div class="ui very padded container">
 
+    {# This is overriding the normal base.html content-wrapper,
+    so we need to include notifications here so they're displayed. #}
     {% block notifications %}
       {% include "includes/utils/messages.html" %}
     {% endblock notifications %}

--- a/readthedocsext/theme/templates/allauth/layouts/base.html
+++ b/readthedocsext/theme/templates/allauth/layouts/base.html
@@ -3,8 +3,8 @@
 {% block content-wrapper %}
   <div class="ui very padded container">
 
-    {# This is overriding the normal base.html content-wrapper,
-    so we need to include notifications here so they're displayed. #}
+    {# This is overriding the normal base.html content-wrapper, #}
+    {# so we need to include notifications here so they're displayed. #}
     {% block notifications %}
       {% include "includes/utils/messages.html" %}
     {% endblock notifications %}

--- a/readthedocsext/theme/templates/allauth/layouts/base.html
+++ b/readthedocsext/theme/templates/allauth/layouts/base.html
@@ -2,6 +2,11 @@
 
 {% block content-wrapper %}
   <div class="ui very padded container">
+
+    {% block notifications %}
+      {% include "includes/utils/messages.html" %}
+    {% endblock notifications %}
+
     <div class="ui centered grid">
       <div class="nine wide computer twelve wide tablet sixteen wide mobile column">
         <div class="ui raised segment">


### PR DESCRIPTION
The allauth templates are overwriting the base templates block:

* https://github.com/readthedocs/ext-theme/blob/main/readthedocsext/theme/templates/allauth/layouts/base.html#L3 is overriding
* https://github.com/readthedocs/ext-theme/blob/main/readthedocsext/theme/templates/base.html#L63

Fixes https://github.com/readthedocs/ext-theme/issues/425