### PR TITLE
Use target="_blank" for external links

### DIFF
--- a/readthedocsext/theme/templates/account/signup.html
+++ b/readthedocsext/theme/templates/account/signup.html
@@ -45,7 +45,7 @@
 {% block authentication_extra %}
   <p class="ui center aligned tiny basic vertically fitted basic cleared segment">
     {% blocktrans trimmed %}
-      By signing up for an account, you agree to our <a href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a> and <a href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>.
+      By signing up for an account, you agree to our <a href="https://docs.readthedocs.io/page/terms-of-service.html" target="_blank">Terms of Service</a> and <a href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>.
     {% endblocktrans %}
   </p>
 {% endblock authentication_extra %}

--- a/readthedocsext/theme/templates/account/signup.html
+++ b/readthedocsext/theme/templates/account/signup.html
@@ -4,15 +4,23 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block head_title %}{% trans "Sign up" %}{% endblock %}
+{% block head_title %}
+  {% trans "Sign up" %}
+{% endblock %}
 
 {% block authentication_header %}
   {% trans "Sign up to continue" %}
 {% endblock authentication_header %}
 
-{% block authentication_vcs_text %}{% trans "Connect account" %}{% endblock %}
-{% block authentication_email_text %}{% trans "Sign up with email" %}{% endblock %}
-{% block authentication_header_text %}{% trans "Sing up using:" %}{% endblock %}
+{% block authentication_vcs_text %}
+  {% trans "Connect account" %}
+{% endblock authentication_vcs_text %}
+{% block authentication_email_text %}
+  {% trans "Sign up with email" %}
+{% endblock authentication_email_text %}
+{% block authentication_header_text %}
+  {% trans "Sing up using:" %}
+{% endblock authentication_header_text %}
 
 {% block authentication_vcs %}
   {# Translators: this will read "Sign up using GitHub", where "sign up" is a verb #}
@@ -27,25 +35,28 @@
     {% endblocktrans %}
   </p>
 
-  <form class="ui form" method="post" action="{% url 'account_signup' %}#/email">
+  <form class="ui form"
+        method="post"
+        action="{% url 'account_signup' %}#/email">
     {% csrf_token %}
     {{ form|crispy }}
     {% if redirect_field_value %}
-      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+      <input type="hidden"
+             name="{{ redirect_field_name }}"
+             value="{{ redirect_field_value }}" />
     {% endif %}
 
     <div class="ui right aligned fluid container">
-      <button class="ui primary button" type="submit">
-        {% trans "Sign up" %}
-      </button>
+      <button class="ui primary button" type="submit">{% trans "Sign up" %}</button>
     </div>
   </form>
-{% endblock %}
+{% endblock authentication_email %}
 
 {% block authentication_extra %}
   <p class="ui center aligned tiny basic vertically fitted basic cleared segment">
     {% blocktrans trimmed %}
-      By signing up for an account, you agree to our <a href="https://docs.readthedocs.io/page/terms-of-service.html" target="_blank">Terms of Service</a> and <a href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>.
+      By signing up for an account, you agree to our <a href="https://docs.readthedocs.io/page/terms-of-service.html"
+    target="_blank">Terms of Service</a> and <a href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>.
     {% endblocktrans %}
   </p>
 {% endblock authentication_extra %}

--- a/readthedocsext/theme/templates/account/signup.html
+++ b/readthedocsext/theme/templates/account/signup.html
@@ -6,7 +6,7 @@
 
 {% block head_title %}
   {% trans "Sign up" %}
-{% endblock %}
+{% endblock head_title %}
 
 {% block authentication_header %}
   {% trans "Sign up to continue" %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -15,9 +15,7 @@
     {% if url_switch_dashboard %}
       <div class="ui small basic fitted center aligned segment">
         <i class="fad fa-sparkles violet icon"></i>
-        <strong>
-          You are using our new beta dashboard.
-        </strong>
+        <strong>You are using our new beta dashboard.</strong>
         <a href="{% url "support" %}">We would love to have your feedback</a>.
         If you encounter problems,
         <a href="{{ url_switch_dashboard }}">return to our normal dashboard</a>.
@@ -53,9 +51,13 @@
                 {% include "builds/includes/build_name.html" with build=build is_page_title=True %}
               </div>
 
-              <div class="ui basic segment loading padded" data-bind="css: { loading: is_loading() }">
-                <div class="ui active progress" data-bind="semanticui: {progress: progress_config()}">
-                  <div class="bar"><div class="progress"></div></div>
+              <div class="ui basic segment loading padded"
+                   data-bind="css: { loading: is_loading() }">
+                <div class="ui active progress"
+                     data-bind="semanticui: {progress: progress_config()}">
+                  <div class="bar">
+                    <div class="progress"></div>
+                  </div>
                   <div class="label"></div>
                 </div>
               </div>
@@ -69,7 +71,8 @@
                 <div class="item">
                   <i class="grey fa-duotone fa-calendar icon"></i>
                   <div class="content" data-bind="if: !is_loading()">
-                    <div data-bind="attr: { 'data-tooltip': date_display() }, text: '{% trans "Build started" %} ' + date_display_since()"></div>
+                    <div data-bind="attr: { 'data-tooltip': date_display() }, text: '{% trans "Build started" %} ' + date_display_since()">
+                    </div>
                   </div>
                 </div>
 
@@ -121,17 +124,18 @@
         <i class="fa-duotone fa-memo-circle-info icon"></i>
         {% trans "Raw log" %}
       </a>
-      <a class="ui item" data-bind="click: toggle_debug, css: {active: show_debug()}">
+      <a class="ui item"
+         data-bind="click: toggle_debug, css: {active: show_debug()}">
         <i class="fa-duotone fa-microscope icon"></i>
         {% trans "Debug" %}
       </a>
       <div class="right menu">
 
         {% if request.user|is_admin:project %}
-          <a
-            class="item ko hidden"
-            data-bind="click: $root.post_child_form, css: { hidden: !can_cancel() }">
-            <form method="post" action="{% url "builds_detail" build.project.slug build.pk %}">
+          <a class="item ko hidden"
+             data-bind="click: $root.post_child_form, css: { hidden: !can_cancel() }">
+            <form method="post"
+                  action="{% url "builds_detail" build.project.slug build.pk %}">
               {% csrf_token %}
             </form>
             <i class="fas fa-xmark-large red icon"></i>
@@ -139,24 +143,19 @@
             {% trans "Cancel" %}
           </a>
 
-          <readthedocs-menu-build-rebuild
-            class="link item ko hidden"
-            data-bind="css: { hidden: !can_retry() }"
-            url="{% url "projects-versions-builds-list" object.project.slug object.version.slug %}"
-            csrf-token="{{ csrf_token }}">
-            <i class="fa-duotone fa-refresh icon"></i>
-            {# Translators: this refers to rebuilding a version build #}
-            {% trans "Rebuild" %}
+          <readthedocs-menu-build-rebuild class="link item ko hidden" data-bind="css: { hidden: !can_retry() }" url="{% url "projects-versions-builds-list" object.project.slug object.version.slug %}" csrf-token="{{ csrf_token }}">
+          <i class="fa-duotone fa-refresh icon"></i>
+          {# Translators: this refers to rebuilding a version build #}
+          {% trans "Rebuild" %}
           </readthedocs-menu-build-rebuild>
         {% endif %}
 
         {% trans "View documentation for this build" as text_view_docs %}
-        <a
-          class="disabled item"
-          data-bind="css: {disabled: !can_view_docs()}, attr: {href: docs_url}"
-          aria-label="{{ text_view_docs }}"
-          target="_blank"
-          title="{{ text_view_docs }}">
+        <a class="disabled item"
+           data-bind="css: {disabled: !can_view_docs()}, attr: {href: docs_url}"
+           aria-label="{{ text_view_docs }}"
+           target="_blank"
+           title="{{ text_view_docs }}">
           <i class="fa-duotone fa-book icon"></i>
           {% trans "View docs" %}
         </a>
@@ -167,13 +166,10 @@
     {% if build.output %}
       {# If we have build output, this is an old build #}
       <p>
-        <button data-bind="visible: !legacy_output(), click: show_legacy_output">
-          {% trans "Show full build output" %}
-        </button>
+        <button data-bind="visible: !legacy_output(), click: show_legacy_output">{% trans "Show full build output" %}</button>
       </p>
 
-      <div data-bind="visible: legacy_output"
-           style="display: none;">
+      <div data-bind="visible: legacy_output" style="display: none;">
         <h3>{% trans "Build Output" %}</h3>
         <pre class="build-output"><span id="build-output">{{ build.output }}</span></pre>
 
@@ -206,11 +202,9 @@
           component, which handles the data the same way as the notification
           list element.
         {% endcomment %}
-        <div class="ko hidden ui attached fitted inverted basic segment" data-bind="css: { hidden: !has_notifications() }, foreach: notifications">
-          <readthedocs-notification
-            inverted=true
-            csrf-token="{{ csrf_token }}"
-            data-bind="webcomponent: {notification: $data}">
+        <div class="ko hidden ui attached fitted inverted basic segment"
+             data-bind="css: { hidden: !has_notifications() }, foreach: notifications">
+          <readthedocs-notification inverted=true csrf-token="{{ csrf_token }}" data-bind="webcomponent: {notification: $data}">
           </readthedocs-notification>
         </div>
 
@@ -219,7 +213,8 @@
           builds, ``error`` is a string and there is no header, so we use a
           generic header instead.
         {% endcomment %}
-        <div class="ko hidden ui attached fitted inverted basic segment" data-bind="css: { hidden: !error() }">
+        <div class="ko hidden ui attached fitted inverted basic segment"
+             data-bind="css: { hidden: !error() }">
           <div class="ui inverted error notification message">
             <div class="header">
               <i class="fad fa-circle-exclamation icon"></i>
@@ -239,30 +234,36 @@
         <div class="ui hidden active dimmer" data-bind="visible: is_loading()">
           <div class="ui text loader">Loading</div>
         </div>
-        <div class="ui basic segment very padded" data-bind="visible: is_loading()"></div>
+        <div class="ui basic segment very padded"
+             data-bind="visible: is_loading()"></div>
 
-        <table
-          class="ui small very basic compact inverted selectable command table"
-          data-bind="visible: commands, foreach: commands"
-          style="display: none;">
+        <table class="ui small very basic compact inverted selectable command table"
+               data-bind="visible: commands, foreach: commands"
+               style="display: none">
           <tbody>
-            <tr class="top aligned command" data-bind="visible: is_visible() || $parent.show_debug()">
+            <tr class="top aligned command"
+                data-bind="visible: is_visible() || $parent.show_debug()">
               <td class="collapsing">
                 <a class="ui icon left floated" data-bind="click: toggle_expanded">
-                  <i class="grey fa-solid fa-angle-right icon" data-bind="class: is_expanded() ? 'fa-angle-down' : 'fa-angle-right'"></i>
+                  <i class="grey fa-solid fa-angle-right icon"
+                     data-bind="class: is_expanded() ? 'fa-angle-down' : 'fa-angle-right'"></i>
                 </a>
               </td>
               <td>
-                <code class="ui text" data-bind="text: command, class: command_class, click: toggle_expanded"></code>
+                <code class="ui text"
+                      data-bind="text: command, class: command_class, click: toggle_expanded"></code>
                 <a class="ui mini inverted label" data-bind="text: run_time() + 's'"></a>
-                <a class="ui mini inverted label" data-bind="text: '{% trans "Exit" %}: ' + exit_code(), visible: exit_code() > 0"></a>
+                <a class="ui mini inverted label"
+                   data-bind="text: '{% trans "Exit" %}: ' + exit_code(), visible: exit_code() > 0"></a>
               </td>
             </tr>
           </tbody>
           <tbody data-bind="visible: is_expanded(), foreach: output_lines">
-            <tr data-bind="css: {'left olive marked': is_selected()}" class="top aligned">
+            <tr data-bind="css: {'left olive marked': is_selected()}"
+                class="top aligned">
               <td class="collapsing line number">
-                <a class="ui small grey left floated text" data-bind="attr: {href: '#' + anchor_id(), 'data-selected': is_selected()}, click: function() { $parents[1].set_selected_line($data) }">
+                <a class="ui small grey left floated text"
+                   data-bind="attr: {href: '#' + anchor_id(), 'data-selected': is_selected()}, click: function() { $parents[1].set_selected_line($data) }">
                   <code data-bind="text: line_number()"></code>
                 </a>
               </td>
@@ -273,8 +274,10 @@
           </tbody>
         </table>
 
-        <div data-bind="visible: is_polling() && !is_loading()" style="display: none;">
-          <div data-bind="visible: is_polling" class="ui active inverted mini centered inline text loader"></div>
+        <div data-bind="visible: is_polling() && !is_loading()"
+             style="display: none">
+          <div data-bind="visible: is_polling"
+               class="ui active inverted mini centered inline text loader"></div>
         </div>
 
       </div>

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -4,7 +4,9 @@
 {% load privacy_tags %}
 {% load static %}
 
-{% block title %}{{ build.project.name }}{% endblock %}
+{% block title %}
+  {{ build.project.name }}
+{% endblock title %}
 
 {% block content-header %}
   {% block build_detail_beta %}
@@ -23,7 +25,7 @@
     {% endif %}
   {% endblock build_detail_beta %}
   {% include "projects/partials/header.html" with builds_active="active" %}
-{% endblock %}
+{% endblock content-header %}
 
 {% block content %}
   <div data-bind="using: BuildDetailView({}, '{% url "build-detail" build.id %}', '{% url "projects-builds-notifications-list" build.project.slug build.id %}')">
@@ -284,4 +286,4 @@
     {% endif %}
 
   </div>
-{% endblock %}
+{% endblock content %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -155,6 +155,7 @@
           class="disabled item"
           data-bind="css: {disabled: !can_view_docs()}, attr: {href: docs_url}"
           aria-label="{{ text_view_docs }}"
+          target="_blank"
           title="{{ text_view_docs }}">
           <i class="fa-duotone fa-book icon"></i>
           {% trans "View docs" %}

--- a/readthedocsext/theme/templates/homepage.html
+++ b/readthedocsext/theme/templates/homepage.html
@@ -10,15 +10,22 @@
         content="{% trans "Read the Docs simplifies technical documentation by automating building, versioning, and hosting for you. Build up-to-date documentation for the web, print, and offline use on every version control push automatically." %}">
 {% endblock extra_metas %}
 
-{% block title %}{% trans "Home" %}{% endblock %}
+{% block title %}
+  {% trans "Home" %}
+{% endblock title %}
 
-{% block body_class %}home {% if not request.user.is_authenticated %}splash{% endif %}{% endblock %}
+{% block body_class %}
+  home
+  {% if not request.user.is_authenticated %}splash{% endif %}
+{% endblock body_class %}
 
-{% block nav-browse %}class="active"{% endblock %}
+{% block nav-browse %}
+  class="active"
+{% endblock nav-browse %}
 
 {% block header %}
   {% include "includes/header.html" %}
-{% endblock %}
+{% endblock header %}
 
 {% block content-wrapper %}
   <!-- Lead -->
@@ -107,22 +114,20 @@
     <div class="ui container">
       <a href="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html"
          target="_blank"
-         class="ui button primary">{% trans 'Getting started guide' %}</a>
+         class="ui button primary">{% trans "Getting started guide" %}</a>
     </div>
   </div>
 
   <!-- Search -->
-  <div class="ui container very padded">
-    {# include "includes/widesearchbar.html" #}
-  </div>
+  <div class="ui container very padded">{# include "includes/widesearchbar.html" #}</div>
 
   {% if featured_list %}
-  {% comment %}
+    {% comment %}
   {% get_current_language as language %}
   {% cache 600 homepage_featured_list language #}
-  {% endcomment %}
+    {% endcomment %}
 
-  <!-- BEGIN projects list -->
+    <!-- BEGIN projects list -->
     <section class="ui container very padded">
       <h2 class="ui large centered header">
         <div class="content">{% trans "Featured Projects" %}</div>
@@ -151,19 +156,17 @@
           {% endfor %}
         {% endwith %}
       </div>
-          {# include "core/project_list_featured.html" #}
+      {# include "core/project_list_featured.html" #}
     </section>
 
-  <!-- END projects list -->
-  {% comment %}{# endcache #}{% endcomment %}
+    <!-- END projects list -->
+    {% comment %}{# endcache #}{% endcomment %}
   {% endif %}
 
   <!-- Funding and Contributing -->
   <section class="ui basic segment very padded">
     <div class="ui container">
-      <h2 class="ui header center aligned">
-        {% trans "Read the Docs is funded by the community" %}
-      </h2>
+      <h2 class="ui header center aligned">{% trans "Read the Docs is funded by the community" %}</h2>
       <p>
 
         {% url "advertising" as advertising_url %}
@@ -184,7 +187,8 @@
         {% blocktrans trimmed %}
           Read the Docs is <strong>community supported</strong>.
           It depends on users like you to contribute to development, support, and operations.
-          You can learn more about how to <a href="https://docs.readthedocs.io/page/contribute.html" target="_blank">contribute</a> in our
+          You can learn more about how to <a href="https://docs.readthedocs.io/page/contribute.html"
+    target="_blank">contribute</a> in our
           docs.
           Thanks so much to our wonderful <a href="https://docs.readthedocs.io/page/team.html" target="_blank">community team</a> who helps us
           run the site.
@@ -199,4 +203,4 @@
       </p>
     </div>
   </section>
-{% endblock %}
+{% endblock content-wrapper %}

--- a/readthedocsext/theme/templates/homepage.html
+++ b/readthedocsext/theme/templates/homepage.html
@@ -106,6 +106,7 @@
   <div class="ui inverted segment basic center aligned very padded">
     <div class="ui container">
       <a href="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html"
+         target="_blank"
          class="ui button primary">{% trans 'Getting started guide' %}</a>
     </div>
   </div>
@@ -183,9 +184,9 @@
         {% blocktrans trimmed %}
           Read the Docs is <strong>community supported</strong>.
           It depends on users like you to contribute to development, support, and operations.
-          You can learn more about how to <a href="https://docs.readthedocs.io/page/contribute.html">contribute</a> in our
+          You can learn more about how to <a href="https://docs.readthedocs.io/page/contribute.html" target="_blank">contribute</a> in our
           docs.
-          Thanks so much to our wonderful <a href="https://docs.readthedocs.io/page/team.html">community team</a> who helps us
+          Thanks so much to our wonderful <a href="https://docs.readthedocs.io/page/team.html" target="_blank">community team</a> who helps us
           run the site.
           Read the Docs wouldn't be possible without them.
         {% endblocktrans %}
@@ -193,7 +194,7 @@
 
       <p>
         {% blocktrans trimmed %}
-          Hosting for the project is graciously provided by <a href="https://azure.microsoft.com/">Microsoft Azure</a>.
+          Hosting for the project is graciously provided by <a href="https://aws.amazon.com/" target="_blank">AWS</a>.
         {% endblocktrans %}
       </p>
     </div>

--- a/readthedocsext/theme/templates/includes/footer.html
+++ b/readthedocsext/theme/templates/includes/footer.html
@@ -36,10 +36,10 @@
           <div class="ui vertical inverted text menu">
             {% block menu_learn %}
               <h4 class="ui inverted sub header">Learn more</h4>
-              <a class="item" href="https://docs.readthedocs.io">Documentation</a>
+              <a class="item" href="https://docs.readthedocs.io" target="_blank">Documentation</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/tutorial/index.html">Getting started guide</a>
-              <a class="item" href="https://docs.readthedocs.io/page/config-file/">Configure your project</a>
+                 href="https://docs.readthedocs.io/page/tutorial/index.html" target="_blank">Getting started guide</a>
+              <a class="item" href="https://docs.readthedocs.io/page/config-file/" target="_blank">Configure your project</a>
             {% endblock menu_learn %}
           </div>
         </div>
@@ -48,13 +48,13 @@
           <div class="ui vertical inverted text menu">
             {% block menu_services %}
               <h4 class="ui inverted sub header">Services</h4>
-              <a class="item" href="https://about.readthedocs.com/pricing/">Pricing</a>
-              <a class="item" href="https://about.readthedocs.com/features/">Features</a>
-              <a class="item" href="https://www.ethicalads.io/advertisers/?ref=rtd">Advertise with Us</a>
+              <a class="item" href="https://about.readthedocs.com/pricing/" target="_blank">Pricing</a>
+              <a class="item" href="https://about.readthedocs.com/features/" target="_blank">Features</a>
+              <a class="item" href="https://www.ethicalads.io/advertisers/?ref=rtd" target="_blank">Advertise with Us</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
+                 href="https://docs.readthedocs.io/page/privacy-policy.html" target="_blank">Privacy Policy</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>
+                 href="https://docs.readthedocs.io/page/terms-of-service.html" target="_blank">Terms of Service</a>
             {% endblock menu_services %}
           </div>
         </div>
@@ -63,15 +63,15 @@
           <div class="ui vertical inverted text menu">
             {% block menu_about %}
               <h4 class="ui inverted sub header">About us</h4>
-              <a class="item" href="https://about.readthedocs.com/company/">Company</a>
-              <a class="item" href="https://docs.readthedocs.io/page/team.html">Team</a>
-              <a class="item" href="https://dev.readthedocs.io/page/contribute.html">Contributing</a>
+              <a class="item" href="https://about.readthedocs.com/company/" target="_blank">Company</a>
+              <a class="item" href="https://docs.readthedocs.io/page/team.html" target="_blank">Team</a>
+              <a class="item" href="https://dev.readthedocs.io/page/contribute.html" target="_blank">Contributing</a>
 
               {# TODO move this out of the footer and drop this menu from this block/column  #}
               <h4 class="ui inverted sub header">Tools</h4>
-              <a class="item" href="https://about.readthedocs.com/tools/sphinx/">Sphinx</a>
-              <a class="item" href="https://about.readthedocs.com/tools/mkdocs/">MkDocs</a>
-              <a class="item" href="https://about.readthedocs.com/tools/jupyter-book/">Jupyter Book</a>
+              <a class="item" href="https://about.readthedocs.com/tools/sphinx/" target="_blank">Sphinx</a>
+              <a class="item" href="https://about.readthedocs.com/tools/mkdocs/" target="_blank">MkDocs</a>
+              <a class="item" href="https://about.readthedocs.com/tools/jupyter-book/" target="_blank">Jupyter Book</a>
             {% endblock menu_about %}
           </div>
         </div>
@@ -87,7 +87,7 @@
             <div class="content">
               <div class="header">{% trans "Version" %}</div>
               <div class="description">
-                <a href="https://docs.readthedocs.io/page/changelog.html">{% readthedocs_version %}</a>
+                <a href="https://docs.readthedocs.io/page/changelog.html" target="_blank">{% readthedocs_version %}</a>
               </div>
             </div>
           </div>

--- a/readthedocsext/theme/templates/includes/footer.html
+++ b/readthedocsext/theme/templates/includes/footer.html
@@ -38,8 +38,11 @@
               <h4 class="ui inverted sub header">Learn more</h4>
               <a class="item" href="https://docs.readthedocs.io" target="_blank">Documentation</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/tutorial/index.html" target="_blank">Getting started guide</a>
-              <a class="item" href="https://docs.readthedocs.io/page/config-file/" target="_blank">Configure your project</a>
+                 href="https://docs.readthedocs.io/page/tutorial/index.html"
+                 target="_blank">Getting started guide</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/config-file/"
+                 target="_blank">Configure your project</a>
             {% endblock menu_learn %}
           </div>
         </div>
@@ -48,13 +51,21 @@
           <div class="ui vertical inverted text menu">
             {% block menu_services %}
               <h4 class="ui inverted sub header">Services</h4>
-              <a class="item" href="https://about.readthedocs.com/pricing/" target="_blank">Pricing</a>
-              <a class="item" href="https://about.readthedocs.com/features/" target="_blank">Features</a>
-              <a class="item" href="https://www.ethicalads.io/advertisers/?ref=rtd" target="_blank">Advertise with Us</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/privacy-policy.html" target="_blank">Privacy Policy</a>
+                 href="https://about.readthedocs.com/pricing/"
+                 target="_blank">Pricing</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/terms-of-service.html" target="_blank">Terms of Service</a>
+                 href="https://about.readthedocs.com/features/"
+                 target="_blank">Features</a>
+              <a class="item"
+                 href="https://www.ethicalads.io/advertisers/?ref=rtd"
+                 target="_blank">Advertise with Us</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/privacy-policy.html"
+                 target="_blank">Privacy Policy</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/terms-of-service.html"
+                 target="_blank">Terms of Service</a>
             {% endblock menu_services %}
           </div>
         </div>
@@ -63,15 +74,27 @@
           <div class="ui vertical inverted text menu">
             {% block menu_about %}
               <h4 class="ui inverted sub header">About us</h4>
-              <a class="item" href="https://about.readthedocs.com/company/" target="_blank">Company</a>
-              <a class="item" href="https://docs.readthedocs.io/page/team.html" target="_blank">Team</a>
-              <a class="item" href="https://dev.readthedocs.io/page/contribute.html" target="_blank">Contributing</a>
+              <a class="item"
+                 href="https://about.readthedocs.com/company/"
+                 target="_blank">Company</a>
+              <a class="item"
+                 href="https://docs.readthedocs.io/page/team.html"
+                 target="_blank">Team</a>
+              <a class="item"
+                 href="https://dev.readthedocs.io/page/contribute.html"
+                 target="_blank">Contributing</a>
 
               {# TODO move this out of the footer and drop this menu from this block/column  #}
               <h4 class="ui inverted sub header">Tools</h4>
-              <a class="item" href="https://about.readthedocs.com/tools/sphinx/" target="_blank">Sphinx</a>
-              <a class="item" href="https://about.readthedocs.com/tools/mkdocs/" target="_blank">MkDocs</a>
-              <a class="item" href="https://about.readthedocs.com/tools/jupyter-book/" target="_blank">Jupyter Book</a>
+              <a class="item"
+                 href="https://about.readthedocs.com/tools/sphinx/"
+                 target="_blank">Sphinx</a>
+              <a class="item"
+                 href="https://about.readthedocs.com/tools/mkdocs/"
+                 target="_blank">MkDocs</a>
+              <a class="item"
+                 href="https://about.readthedocs.com/tools/jupyter-book/"
+                 target="_blank">Jupyter Book</a>
             {% endblock menu_about %}
           </div>
         </div>
@@ -87,7 +110,8 @@
             <div class="content">
               <div class="header">{% trans "Version" %}</div>
               <div class="description">
-                <a href="https://docs.readthedocs.io/page/changelog.html" target="_blank">{% readthedocs_version %}</a>
+                <a href="https://docs.readthedocs.io/page/changelog.html"
+                   target="_blank">{% readthedocs_version %}</a>
               </div>
             </div>
           </div>

--- a/readthedocsext/theme/templates/profiles/partials/token_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/token_list.html
@@ -35,7 +35,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/api/v3.html#token"
-     aria-label="{% trans "Learn more about API tokens in our documentation" %}">
+     aria-label="{% trans "Learn more about API tokens in our documentation" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/profiles/partials/token_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/token_list.html
@@ -16,13 +16,13 @@
   {% endcomment %}
   <form method="post" action="{% url "profiles_tokens_create" %}">
     {% csrf_token %}
-    <button class="ui green {% if objects %}disabled {% endif %}button">
-      {% trans "Generate API token" %}
-    </button>
+    <button class="ui green {% if objects %}disabled{% endif %}button">{% trans "Generate API token" %}</button>
   </form>
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}key{% endblock %}
+{% block list_placeholder_icon_class %}
+  key
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     You currently have no API tokens.
@@ -33,12 +33,12 @@
     {% endblocktrans %}
   </div>
 {% endblock list_placeholder_header %}
+
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/api/v3.html#token"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/api/v3.html#token"
      aria-label="{% trans "Learn more about API tokens in our documentation" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_menu %}

--- a/readthedocsext/theme/templates/profiles/private/advertising_profile.html
+++ b/readthedocsext/theme/templates/profiles/private/advertising_profile.html
@@ -5,11 +5,13 @@
 
 {% block title %}
   {% trans "Set advertising preferences" %}
-{% endblock %}
-{% block profile_admin_advertising %}active{% endblock %}
+{% endblock title %}
+{% block profile_admin_advertising %}
+  active
+{% endblock  profile_admin_advertising %}
 {% block edit_content_header %}
   {% trans "Set advertising preferences" %}
-{% endblock %}
+{% endblock edit_content_header %}
 
 {% block edit_content %}
   {% if request.user.gold.exists or request.user.goldonce.exists %}
@@ -42,7 +44,7 @@
     {% url "gold_detail" as gold_detail %}
     {% url "donate" as donate_url %}
     {% blocktrans trimmed %}
-      You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold member</a> or <a href="{{ donate_url }}">Supporter</a> of Read the Docs</a>.
+      You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold member</a> or <a href="{{ donate_url }}">Supporter of Read the Docs</a>.
     {% endblocktrans %}
   </p>
 
@@ -55,4 +57,4 @@
            value="{% trans "Update advertisement preference" %}"
            id="submit" />
   </form>
-{% endblock %}
+{% endblock edit_content %}

--- a/readthedocsext/theme/templates/profiles/private/advertising_profile.html
+++ b/readthedocsext/theme/templates/profiles/private/advertising_profile.html
@@ -3,16 +3,20 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{% trans "Set advertising preferences" %}{% endblock %}
+{% block title %}
+  {% trans "Set advertising preferences" %}
+{% endblock %}
 {% block profile_admin_advertising %}active{% endblock %}
-{% block edit_content_header %} {% trans "Set advertising preferences" %} {% endblock %}
+{% block edit_content_header %}
+  {% trans "Set advertising preferences" %}
+{% endblock %}
 
 {% block edit_content %}
   {% if request.user.gold.exists or request.user.goldonce.exists %}
     <p>
       {% blocktrans trimmed %}
         Thank you for supporting Read the Docs!
-      {% endblocktrans%}
+      {% endblocktrans %}
     </p>
   {% endif %}
 
@@ -29,7 +33,8 @@
       For more details on advertising on Read the Docs
       including the privacy protections we have in place for users
       and community advertising we run on behalf of the open source community,
-      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html" target="_blank">our documentation</a>.
+      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html"
+    target="_blank">our documentation</a>.
     {% endblocktrans %}
   </p>
 
@@ -44,6 +49,10 @@
   <form class="ui form" method="POST" action=".">
     {% csrf_token %}
     {{ form|crispy }}
-    <input class="ui button" type="submit" name="submit" value="{% trans "Update advertisement preference" %}" id="submit"/>
+    <input class="ui button"
+           type="submit"
+           name="submit"
+           value="{% trans "Update advertisement preference" %}"
+           id="submit" />
   </form>
 {% endblock %}

--- a/readthedocsext/theme/templates/profiles/private/advertising_profile.html
+++ b/readthedocsext/theme/templates/profiles/private/advertising_profile.html
@@ -29,7 +29,7 @@
       For more details on advertising on Read the Docs
       including the privacy protections we have in place for users
       and community advertising we run on behalf of the open source community,
-      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html">our documentation</a>.
+      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html" target="_blank">our documentation</a>.
     {% endblocktrans %}
   </p>
 

--- a/readthedocsext/theme/templates/profiles/private/security_log.html
+++ b/readthedocsext/theme/templates/profiles/private/security_log.html
@@ -14,7 +14,7 @@
   <div class="ui small info message">
     <i class="fas fa-question-circle icon"></i>
     {% blocktrans trimmed with days_limit=days_limit docs_url="https://docs.readthedocs.io/page/security-log.html#user-security-log" %}
-      The <a href="{{ docs_url }}" aria-label="Learn more about user security logs in our documentation">user security log</a> allows you to see what has happened recently in your account.
+      The <a href="{{ docs_url }}" aria-label="Learn more about user security logs in our documentation" target="_blank">user security log</a> allows you to see what has happened recently in your account.
       Logs are kept for the last {{ days_limit }} days.
     {% endblocktrans %}
   </div>

--- a/readthedocsext/theme/templates/profiles/private/security_log.html
+++ b/readthedocsext/theme/templates/profiles/private/security_log.html
@@ -2,20 +2,28 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Security log" %}{% endblock %}
-{% block profile-admin-security-log %}active{% endblock %}
-{% block edit_content_header %} {% trans "Security log" %} {% endblock %}
+{% block title %}
+  {% trans "Security log" %}
+{% endblock title %}
+{% block profile-admin-security-log %}
+  active
+{% endblock profile-admin-security-log %}
+{% block edit_content_header %}
+  {% trans "Security log" %}
+{% endblock edit_content_header %}
 
 {% block edit_content %}
   {% include "audit/partials/log_list.html" with objects=object_list omit_user=True %}
-{% endblock %}
+{% endblock edit_content %}
 
 {% block edit_sidebar %}
   <div class="ui small info message">
     <i class="fas fa-question-circle icon"></i>
     {% blocktrans trimmed with days_limit=days_limit docs_url="https://docs.readthedocs.io/page/security-log.html#user-security-log" %}
-      The <a href="{{ docs_url }}" aria-label="Learn more about user security logs in our documentation" target="_blank">user security log</a> allows you to see what has happened recently in your account.
+      The <a href="{{ docs_url }}"
+    aria-label="Learn more about user security logs in our documentation"
+    target="_blank">user security log</a> allows you to see what has happened recently in your account.
       Logs are kept for the last {{ days_limit }} days.
     {% endblocktrans %}
   </div>
-{% endblock %}
+{% endblock edit_sidebar %}

--- a/readthedocsext/theme/templates/projects/environmentvariable_list.html
+++ b/readthedocsext/theme/templates/projects/environmentvariable_list.html
@@ -2,14 +2,20 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Environment variables" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Environment variables" %}
+{% endblock title %}
 
-{% block project_environment_variables_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Environment variables" %}{% endblock %}
+{% block project_environment_variables_active %}
+  active
+{% endblock project_environment_variables_active %}
+{% block project_edit_content_header %}
+  {% trans "Environment variables" %}
+{% endblock project_edit_content_header %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/environment_variable_list.html" with objects=object_list %}
-{% endblock %}
+{% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
   {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/environment-variables.html" text="How to use custom environment variables" is_external=True class="item" %}

--- a/readthedocsext/theme/templates/projects/integration_webhook_detail.html
+++ b/readthedocsext/theme/templates/projects/integration_webhook_detail.html
@@ -117,7 +117,7 @@
     <p>
       {% blocktrans trimmed %}
         For more information on manually configuring a webhook, refer to
-        <a href="https://docs.readthedocs.io/page/webhooks.html">our webhook documentation.</a>
+        <a href="https://docs.readthedocs.io/page/webhooks.html" target="_blank">our webhook documentation.</a>
       {% endblocktrans %}
     </p>
   {% endif %}

--- a/readthedocsext/theme/templates/projects/onboard_detail.html
+++ b/readthedocsext/theme/templates/projects/onboard_detail.html
@@ -34,7 +34,7 @@
                 Your documentation has been built.
                 Ensure your documentation is kept up to date with every commit to
                 your repository, by
-                <a href="http://docs.readthedocs.io/page/webhooks.html">setting up a webhook</a>.
+                <a href="http://docs.readthedocs.io/page/webhooks.html" target="_blank">setting up a webhook</a>.
               {% endblocktrans %}
             </p>
 
@@ -50,7 +50,7 @@
                 There was a problem building your documentation,
                 you can see what went wrong in the build output.
                 If you need more help, check out some of the
-                <a href="http://docs.readthedocs.io/page/faq.html">problems frequently encountered</a>
+                <a href="http://docs.readthedocs.io/page/faq.html" target="_blank">problems frequently encountered</a>
                 during builds.
               {% endblocktrans %}
             </p>

--- a/readthedocsext/theme/templates/projects/onboard_detail.html
+++ b/readthedocsext/theme/templates/projects/onboard_detail.html
@@ -16,10 +16,14 @@
         {% endblocktrans %}
       </p>
 
-      <form class="ui form" method="post" action="{% url "projects_detail" project.slug %}">
+      <form class="ui form"
+            method="post"
+            action="{% url "projects_detail" project.slug %}">
         {% csrf_token %}
         <input type="hidden" name="version_slug" value="latest" />
-        <input class="ui button primary" type="submit" value="{% trans "Build latest version" %}" />
+        <input class="ui button primary"
+               type="submit"
+               value="{% trans "Build latest version" %}" />
       </form>
     {% else %}
 
@@ -34,34 +38,42 @@
                 Your documentation has been built.
                 Ensure your documentation is kept up to date with every commit to
                 your repository, by
-                <a href="http://docs.readthedocs.io/page/webhooks.html" target="_blank">setting up a webhook</a>.
+                <a href="https://docs.readthedocs.io/page/webhooks.html" target="_blank">setting up a webhook</a>.
               {% endblocktrans %}
             </p>
 
-            <input class="ui button primary" type="submit" value="{% trans "View your documentation" %}"/>
+            <input class="ui button primary"
+                   type="submit"
+                   value="{% trans "View your documentation" %}" />
           </form>
         {% else %}
           {% comment %}Last build failed{% endcomment %}
           <h2>{% trans "Your documentation failed to build" %}</h2>
 
-          <form class="ui form" method="get" action="{% url "builds_detail" project_slug=project.slug build_pk=onboard.build.pk %}">
+          <form class="ui form"
+                method="get"
+                action="{% url "builds_detail" project_slug=project.slug build_pk=onboard.build.pk %}">
             <p>
               {% blocktrans trimmed %}
                 There was a problem building your documentation,
                 you can see what went wrong in the build output.
                 If you need more help, check out some of the
-                <a href="http://docs.readthedocs.io/page/faq.html" target="_blank">problems frequently encountered</a>
+                <a href="https://docs.readthedocs.io/page/faq.html" target="_blank">problems frequently encountered</a>
                 during builds.
               {% endblocktrans %}
             </p>
 
-            <input class="ui button" type="submit" value="{% trans "View build output" %}"/>
+            <input class="ui button"
+                   type="submit"
+                   value="{% trans "View build output" %}" />
           </form>
         {% endif %}
       {% else %}
 
         {% url "builds_detail" project_slug=project.slug build_pk=onboard.build.pk as latest_build_url %}
-        <a href="{{ latest_build_url }}"><h2>{% trans "Your documentation is building" %}</h2></a>
+        <a href="{{ latest_build_url }}">
+          <h2>{% trans "Your documentation is building" %}</h2>
+        </a>
 
         <p>
           {% blocktrans trimmed %}

--- a/readthedocsext/theme/templates/projects/onboard_import.html
+++ b/readthedocsext/theme/templates/projects/onboard_import.html
@@ -10,14 +10,14 @@
         {% blocktrans trimmed %}
           You don't have any projects yet, but you can start building documentation by importing one.
           Not sure how to start documenting your project?
-          Check out the <a href="{{ getting_started_url }}">Getting Started Guide</a> to learn how.
+          Check out the <a href="{{ getting_started_url }}" target="_blank">Getting Started Guide</a> to learn how.
         {% endblocktrans %}
       </p>
 
       <p>
         {% url "projects_import_demo" as import_demo_url %}
         {% blocktrans trimmed %}
-          Want to try a demo? <a href="{{ import_demo_url }}">Import our own demo project</a>.
+          Want to try a demo? <a href="{{ import_demo_url }}" target="_blank">Import our own demo project</a>.
         {% endblocktrans %}
       </p>
 

--- a/readthedocsext/theme/templates/projects/onboard_import.html
+++ b/readthedocsext/theme/templates/projects/onboard_import.html
@@ -2,7 +2,11 @@
 
 <!-- BEGIN onboard import project -->
 <div>
-  <h2>{% trans "Ready to share your documentation" %}{% if request.user.first_name %}, {{ request.user.first_name }}{% endif %}?</h2>
+  <h2>
+    {% trans "Ready to share your documentation" %}
+    {% if request.user.first_name %}, {{ request.user.first_name }}{% endif %}
+    ?
+  </h2>
 
   {% with getting_started_url="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" %}
     <form class="ui form" method="get" action="{% url "projects_import" %}">
@@ -21,7 +25,9 @@
         {% endblocktrans %}
       </p>
 
-      <input class="ui button" type="submit" value="{% trans "Import a Project" %}"/>
+      <input class="ui button"
+             type="submit"
+             value="{% trans "Import a Project" %}" />
     </form>
   {% endwith %}
 </div>

--- a/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
@@ -33,6 +33,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
+     target="_blank"
      href="https://docs.readthedocs.io/page/automation-rules.html">{% trans "Learn more" %}</a>.
 {% endblock list_placeholder_text %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
@@ -30,9 +30,11 @@
   {% url "projects_domains_create" project.slug as create_url %}
   {% trans "Add domain" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-at{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-at
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No domains are currently configured.

--- a/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
@@ -45,11 +45,10 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/custom-domains.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/guides/custom-domains.html"
      target="_blank"
-     aria-label="{% trans "Learn more about custom domains in our documentation" %}">
-    {% trans "Learn more" %}
-  </a>
+     aria-label="{% trans "Learn more about custom domains in our documentation" %}">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
@@ -69,20 +68,18 @@
 {% endblock list_item_image %}
 
 {% block list_item_header %}
-  <a href="{% url 'projects_domains_edit' project.slug object.pk %}">
-    {{ object.domain }}
-  </a>
+  <a href="{% url 'projects_domains_edit' project.slug object.pk %}">{{ object.domain }}</a>
 {% endblock list_item_header %}
 
 {% block list_item_meta_items %}
   <div class="item">
-    {% if object.https  %}
+    {% if object.https %}
       <div class="ui basic label">
         <i class="fa-duotone fa-shield-check icon"></i>
         {% trans "HTTPS enabled" %}
       </div>
     {% endif %}
-    {% if object.domainssl  %}
+    {% if object.domainssl %}
       <div class="ui basic label">
         <i class="fa-duotone fa-tachometer icon"></i>
         {% trans "CDN enabled" %}

--- a/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
@@ -46,6 +46,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/guides/custom-domains.html"
+     target="_blank"
      aria-label="{% trans "Learn more about custom domains in our documentation" %}">
     {% trans "Learn more" %}
   </a>

--- a/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
@@ -15,9 +15,11 @@
   {% url "projects_environmentvariables_create" project_slug=project.slug as create_url %}
   {% trans "Add variable" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-shield-keyhole{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-shield-keyhole
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No environment variables have been configured yet

--- a/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
@@ -32,7 +32,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/guides/environment-variables.html"
-     aria-label="{% trans "Learn more about user-defined environment variables in our documentation" %}">
+     aria-label="{% trans "Learn more about user-defined environment variables in our documentation" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
@@ -31,18 +31,17 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/environment-variables.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/guides/environment-variables.html"
      aria-label="{% trans "Learn more about user-defined environment variables in our documentation" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
   <div class="ui button"
-       data-clipboard-text="{{ object.name }}"
-       {# Translators: past tense as this shown after clicking #}
-       data-content="{% trans "Copied!" %}">
+    data-clipboard-text="{{ object.name }}"
+    {# Translators: past tense as this shown after clicking #}
+    data-content="{% trans "Copied!" %}">
     <i class="fa-solid fa-clipboard icon"></i>
   </div>
 
@@ -73,7 +72,8 @@
       {% else %}
         {% spaceless %}
           {# Avoid exposing short secrets #}
-          {% if object.value|length > 4 %}{{ object.value|slice:"0:4" }}{% endif %}****
+          {% if object.value|length > 4 %}{{ object.value|slice:"0:4" }}{% endif %}
+          ****
         {% endspaceless %}
       {% endif %}
     </code>

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -13,9 +13,11 @@
   {% url "projects_integrations_create" project_slug=project.slug as create_url %}
   {% trans "Add integration" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-plug{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-plug
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No integrations have been configured yet

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -28,7 +28,8 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html"
      target="_blank"
      aria-label="{% trans "Learn more about connecting your Git provider in our documentation" %}">
     {% trans "Learn more" %}
@@ -58,12 +59,11 @@
     {{ object.get_integration_type_display }}
   </a>
   {% if object.has_sync and object.can_sync %}
-    <i class="fa-duotone fa-wand-magic-sparkles icon" data-content="{% trans "Automatically managed" %}"></i>
+    <i class="fa-duotone fa-wand-magic-sparkles icon"
+       data-content="{% trans "Automatically managed" %}"></i>
   {% endif %}
 {% endblock list_item_header %}
 
 {% block list_item_meta %}
-  <div class="item">
-    {{ object.exchanges.count }} exchanges
-  </div>
+  <div class="item">{{ object.exchanges.count }} exchanges</div>
 {% endblock list_item_meta %}

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -29,6 +29,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html"
+     target="_blank"
      aria-label="{% trans "Learn more about connecting your Git provider in our documentation" %}">
     {% trans "Learn more" %}
   </a>

--- a/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
@@ -35,7 +35,7 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/importing-private-repositories.html">{% trans "Learn more" %}</a>.
+  <a class="ui button" href="https://docs.readthedocs.io/page/guides/importing-private-repositories.html" target="_blank">{% trans "Learn more" %}</a>.
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}

--- a/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
@@ -13,7 +13,8 @@
   Do not show an empty menu bar at the top. Once users can add SSH keys, we can
   remove this override and enable the ``create_button`` block
 {% endcomment %}
-{% block top_menu %}{% endblock %}
+{% block top_menu %}
+{% endblock top_menu %}
 {% block create_button %}
   {% comment %}
   {# TODO this is not supported currently, and is an admin only action #}
@@ -21,9 +22,11 @@
   {% trans "Add SSH key" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
   {% endcomment %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-lock-keyhole{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-lock-keyhole
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No SSH keys are configured for this project.
@@ -53,5 +56,7 @@
   </a>
 {% endblock list_item_header %}
 
-{% block list_item_meta %}{% endblock %}
-{% block list_item_extra %}{% endblock %}
+{% block list_item_meta %}
+{% endblock list_item_meta %}
+{% block list_item_extra %}
+{% endblock list_item_extra %}

--- a/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
@@ -35,7 +35,9 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/importing-private-repositories.html" target="_blank">{% trans "Learn more" %}</a>.
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/guides/importing-private-repositories.html"
+     target="_blank">{% trans "Learn more" %}</a>.
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}

--- a/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
@@ -15,9 +15,11 @@
   {% url "projects_notifications_create" project.slug as create_url %}
   {% trans "Add notification" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-envelope-dot{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-envelope-dot
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No email notifications have been configured yet

--- a/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
@@ -32,7 +32,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/guides/build-notifications.html#email-notifications"
-     aria-label="{% trans "Learn more about email notifications in our documentation" %}">
+     aria-label="{% trans "Learn more about email notifications in our documentation" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
@@ -31,11 +31,10 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/build-notifications.html#email-notifications"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/guides/build-notifications.html#email-notifications"
      aria-label="{% trans "Learn more about email notifications in our documentation" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -29,6 +29,7 @@
 {% block list_placeholder_text %}
   <a class="ui button"
      href="https://docs.readthedocs.io/page/guides/redirects.html"
+     target="_blank"
      aria-label="{% trans "Learn more about custom redirects in our documentation" %}">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/search_query_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/search_query_list.html
@@ -46,7 +46,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/guides/search-analytics.html"
-     aria-label="{% trans "Learn more about this feature in our documentation pages" %}">
+     aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/search_query_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/search_query_list.html
@@ -31,9 +31,11 @@
     <i class="fa-duotone fa-download icon"></i>
     {% trans "Download search data" %}
   </a>
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-magnifying-glass{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-magnifying-glass
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No search queries are available yet
@@ -44,18 +46,22 @@
     {% endblocktrans %}
   </div>
 {% endblock list_placeholder_header %}
+
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/search-analytics.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/guides/search-analytics.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_menu %}
   <div class="ui right floated text menu">
     <div class="item">
-      {% blocktrans trimmed count num=object.1 %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
+      {% blocktrans trimmed count num=object.1 %}
+        {{ num }} query
+      {% plural %}
+        {{ num }} queries
+      {% endblocktrans %}
     </div>
   </div>
 {% endblock list_item_right_menu %}
@@ -63,7 +69,11 @@
 {% block list_item_header %}
   {{ object.0 }}
   <div class="sub header">
-    {% blocktrans trimmed count num=object.2 %}{{ num }} result{% plural %}{{ num }} results{% endblocktrans %}
+    {% blocktrans trimmed count num=object.2 %}
+      {{ num }} result
+    {% plural %}
+      {{ num }} results
+    {% endblocktrans %}
   </div>
 
 {% endblock list_item_header %}

--- a/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
@@ -31,7 +31,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/en/stable/guides/subprojects.html"
-     aria-label="{% trans "Learn more about this feature in our documentation pages" %}">
+     aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
@@ -15,9 +15,11 @@
   {% url "projects_subprojects_create" project_slug=project.slug as create_url %}
   {% trans "Add subproject" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-sitemap{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-sitemap
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No subprojects exist yet
@@ -29,12 +31,12 @@
     {% endblocktrans %}
   </div>
 {% endblock list_placeholder_header %}
+
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/en/stable/guides/subprojects.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/en/stable/guides/subprojects.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
@@ -56,12 +58,8 @@
 {% endblock list_item_image %}
 
 {% block list_item_header %}
-  <a href="{% url 'projects_manage' project_slug=object.child.slug %}">
-    {{ object.child.name }}
-  </a>
-  <a class="sub header" href="{{ object.get_absolute_url }}">
-    {{ object.get_absolute_url|truncatechars:60 }}
-  </a>
+  <a href="{% url 'projects_manage' project_slug=object.child.slug %}">{{ object.child.name }}</a>
+  <a class="sub header" href="{{ object.get_absolute_url }}">{{ object.get_absolute_url|truncatechars:60 }}</a>
 {% endblock list_item_header %}
 
 {% block list_item_meta_list %}

--- a/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
@@ -27,7 +27,7 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/commercial/sharing.html">{% trans "Learn more" %}</a>.
+  <a class="ui button" href="https://docs.readthedocs.io/page/commercial/sharing.html" target="_blank">{% trans "Learn more" %}</a>.
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}

--- a/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
@@ -13,9 +13,11 @@
   {% url "projects_temporary_access_create" project.slug as create_url %}
   {% trans "Add share" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-share-nodes{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-share-nodes
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No active shares are configured yet
@@ -26,8 +28,11 @@
     {% endblocktrans %}
   </div>
 {% endblock list_placeholder_header %}
+
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/commercial/sharing.html" target="_blank">{% trans "Learn more" %}</a>.
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/commercial/sharing.html"
+     target="_blank">{% trans "Learn more" %}</a>.
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
@@ -51,11 +56,14 @@
 
 {% block list_item_icon %}
   {% if object.access_type == "password" %}
-    <i class="fa-duotone fa-pen-field icon" data-content="{{ object.get_access_type_display }}"></i>
+    <i class="fa-duotone fa-pen-field icon"
+       data-content="{{ object.get_access_type_display }}"></i>
   {% elif object.access_type == "token" %}
-    <i class="fa-duotone fa-link icon" data-content="{{ object.get_access_type_display }}"></i>
+    <i class="fa-duotone fa-link icon"
+       data-content="{{ object.get_access_type_display }}"></i>
   {% elif object.access_type == "http_header_token" %}
-    <i class="fa-duotone fa-code icon" data-content="{{ object.get_access_type_display }}"></i>
+    <i class="fa-duotone fa-code icon"
+       data-content="{{ object.get_access_type_display }}"></i>
   {% endif %}
 {% endblock list_item_icon %}
 
@@ -96,12 +104,8 @@
   {# There is no reason to show expired status here as these shares just disappear #}
   <div class="item">
     <div class="content">
-      <div class="header">
-        {% trans "Expires" %}
-      </div>
-      <div class="description">
-        {{ object.expires }}
-      </div>
+      <div class="header">{% trans "Expires" %}</div>
+      <div class="description">{{ object.expires }}</div>
     </div>
   </div>
-{% endblock %}
+{% endblock list_item_extra_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
@@ -33,7 +33,9 @@
   </a>
 {% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-chart-mixed{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-chart-mixed
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     Traffic data is not available yet
@@ -45,23 +47,20 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/en/stable/analytics.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/en/stable/analytics.html"
      aria-label="{% trans "Learn more about traffic analytics in our documentation" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_menu %}
   <div class="ui right floated text menu">
-    <div class="item">
-      {{ object.2 }}
-    </div>
+    <div class="item">{{ object.2 }}</div>
   </div>
 {% endblock list_item_right_menu %}
 
 {% block list_item_header %}
-  <a href="{{ object.1}}">{{ object.0 }}</a>
+  <a href="{{ object.1 }}">{{ object.0 }}</a>
 {% endblock list_item_header %}
 
 {% block list_item_meta %}

--- a/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
@@ -46,7 +46,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/en/stable/analytics.html"
-     aria-label="{% trans "Learn more about traffic analytics in our documentation" %}">
+     aria-label="{% trans "Learn more about traffic analytics in our documentation" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
@@ -15,9 +15,11 @@
   {% url "projects_translations_create" project.slug as create_url %}
   {% trans "Add translation" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-language{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-language
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No translations exist yet
@@ -30,19 +32,16 @@
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/localization.html"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/localization.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
-      target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
   {% comment %}
     {# TODO there is no edit view for this model, only create and delete #}
-  <a class="ui button"
-     href="{% url 'projects_translations_edit' project_slug=project.slug translation_pk=object.pk %}"
-     data-content="{% trans "Edit translation" %}">
+  <a class="ui button" href="{% url 'projects_translations_edit' project_slug=project.slug translation_pk=object.pk %}" data-content="{% trans "Edit translation" %}">
     <i class="fas fa-wrench icon"></i>
   </a>
   {% endcomment %}
@@ -61,12 +60,8 @@
 {% endblock list_item_image %}
 
 {% block list_item_header %}
-  <a href="{{ object.get_absolute_url }}">
-    {{ object.name }}
-  </a>
-  <div class="sub header">
-    {{ object.get_language_display }}
-  </div>
+  <a href="{{ object.get_absolute_url }}">{{ object.name }}</a>
+  <div class="sub header">{{ object.get_language_display }}</div>
 {% endblock list_item_header %}
 
 {% block list_item_meta %}

--- a/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
@@ -31,7 +31,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/localization.html"
-     aria-label="{% trans "Learn more about this feature in our documentation pages" %}">
+     aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
+      target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
@@ -25,7 +25,8 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button" href="https://docs.readthedocs.io/page/guides/build-notifications.html#build-status-webhooks"
-     aria-label="{% trans "Learn more about webhooks in our documentation" %}">
+     aria-label="{% trans "Learn more about webhooks in our documentation" %}"
+     target="_blank">
     {% trans "Learn more" %}
   </a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
@@ -10,9 +10,11 @@
   {% url "projects_webhooks_create" project.slug as create_url %}
   {% trans "Add webhook" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-webhook{% endblock %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-webhook
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No webhooks have been configured yet
@@ -23,12 +25,12 @@
     {% endblocktrans %}
   </div>
 {% endblock list_placeholder_header %}
+
 {% block list_placeholder_text %}
-  <a class="ui button" href="https://docs.readthedocs.io/page/guides/build-notifications.html#build-status-webhooks"
+  <a class="ui button"
+     href="https://docs.readthedocs.io/page/guides/build-notifications.html#build-status-webhooks"
      aria-label="{% trans "Learn more about webhooks in our documentation" %}"
-     target="_blank">
-    {% trans "Learn more" %}
-  </a>
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}
@@ -50,9 +52,7 @@
 {% endblock list_item_icon %}
 
 {% block list_item_header %}
-  <a href="{% url 'projects_webhooks_edit' project.slug object.pk %}">
-    {{ object.url }}
-  </a>
+  <a href="{% url 'projects_webhooks_edit' project.slug object.pk %}">{{ object.url }}</a>
   <div class="sub header">
     {% trans "Subscribed events:" %}
     {{ object.events.all|join:", " }}

--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -27,20 +27,14 @@
 {% block project_add_automatic_search %}
   <div class="ui small error message"
        data-bind="visible: error"
-       style="display: none;">
-    {% trans "There was an error while syncing your remote repositories" %}
-  </div>
+       style="display: none">{% trans "There was an error while syncing your remote repositories" %}</div>
 
   {# Search prompt and dropdown #}
-  <label>
-    {% trans "Repository name:" %}
-  </label>
-  <div class="ui fluid disabled loading search" data-bind="semanticui: {search: search_config()}, css: {disabled: is_loading(), loading: is_loading()}">
+  <label>{% trans "Repository name:" %}</label>
+  <div class="ui fluid disabled loading search"
+       data-bind="semanticui: {search: search_config()}, css: {disabled: is_loading(), loading: is_loading()}">
     <div class="ui fluid icon large input">
-      <input
-        class="ui text"
-        type="text"
-        autofocus=true />
+      <input class="ui text" type="text" autofocus=true />
       <i class="fa-duotone fa-search icon"></i>
     </div>
     <div class="results"></div>
@@ -67,18 +61,9 @@
       <div class="title">
         <span class="text" data-bind="text: full_name"></span>
         {# Because of the search popup, a nested popup using data-content doesn't do anything here #}
-        <i class="fa-duotone fa-eye-slash small icon"
-           style="display: none"
-           data-bind="visible: private"
-           data-content="{% trans "Repository is private" %}"></i>
-        <i class="fa-duotone fa-magic small icon"
-           style="display: none"
-           data-bind="visible: admin"
-           data-content="{% trans "Repository can be automatically configured" %}"></i>
-        <i class="fa-duotone fa-download small icon"
-           style="display: none"
-           data-bind="visible: has_project"
-           data-content="{% trans "Repository is already configured" %}"></i>
+        <i class="fa-duotone fa-eye-slash small icon" style="display: none" data-bind="visible: private" data-content="{% trans "Repository is private" %}"></i>
+        <i class="fa-duotone fa-magic small icon" style="display: none" data-bind="visible: admin" data-content="{% trans "Repository can be automatically configured" %}"></i>
+        <i class="fa-duotone fa-download small icon" style="display: none" data-bind="visible: has_project" data-content="{% trans "Repository is already configured" %}"></i>
       </div>
       <div class="description">
         <span data-bind="text: clone_url"></span>
@@ -94,7 +79,8 @@
 {% endblock project_add_automatic_search %}
 
 {% block project_add_automatic_placeholder %}
-  <div class="ui basic horizontally fitted segment" data-bind="visible: !is_selected()">
+  <div class="ui basic horizontally fitted segment"
+       data-bind="visible: !is_selected()">
     <div class="ui top attached placeholder segment">
       <div class="ui icon header">
         {# Push user towards searching using input above #}
@@ -116,9 +102,8 @@
 
       {% trans "Can't find the repository you are searching for?" %}
 
-      <button
-        class="ui mini black basic compact right aligned button"
-        data-bind="click: sync_remote_repos, css: {disabled: is_syncing(), loading: is_syncing()}">
+      <button class="ui mini black basic compact right aligned button"
+              data-bind="click: sync_remote_repos, css: {disabled: is_syncing(), loading: is_syncing()}">
         <i class="fa-duotone fa-refresh icon"></i>
         {% trans "Refresh your repositories" %}
       </button>
@@ -138,9 +123,12 @@
     connected and why the repository can/cannot be used.
 
   {% endcomment %}
-  <div class="ui fluid card" data-bind="visible: is_selected, with: selected" style="display: none;">
+  <div class="ui fluid card"
+       data-bind="visible: is_selected, with: selected"
+       style="display: none">
     <div class="content">
-      <img class="ui right floated mini rounded image" data-bind="attr: { src: avatar_url }">
+      <img class="ui right floated mini rounded image"
+           data-bind="attr: { src: avatar_url }">
       <div class="header" data-bind="text: full_name"></div>
       <div class="meta" data-bind="text: clone_url"></div>
       <div class="description">
@@ -153,11 +141,10 @@
               <i class="fa-duotone fa-eye icon" data-bind="css: {'slash': private}"></i>
               <div class="content">
                 <div class="header">
-                  <span data-bind="visible: !private">
-                    {% trans "Repository is public" %}
-                  </span>
+                  <span data-bind="visible: !private">{% trans "Repository is public" %}</span>
 
-                  <span class="ui text" data-bind="visible: private, css: { red: !$parent.is_repository_supported($data) }">
+                  <span class="ui text"
+                        data-bind="visible: private, css: { red: !$parent.is_repository_supported($data) }">
                     {% trans "Repository is private" %}
                   </span>
                 </div>
@@ -168,12 +155,14 @@
                     {% endblocktrans %}
                   </span>
 
-                  <p class="ui red text" data-bind="visible: !$parent.is_repository_supported($data)">
+                  <p class="ui red text"
+                     data-bind="visible: !$parent.is_repository_supported($data)">
                     {% blocktrans trimmed %}
                       Private repositories are not supported
                     {% endblocktrans %}
                   </p>
-                  <p class="ui red text" data-bind="visible: !$parent.is_repository_supported($data)">
+                  <p class="ui red text"
+                     data-bind="visible: !$parent.is_repository_supported($data)">
                     <a class="ui red mini basic button">{% trans "Read more" %}</a>
                   </p>
                 </div>
@@ -186,13 +175,9 @@
               <i class="fa-duotone fa-magic icon" data-bind="css: {red: !admin}"></i>
               <div class="content">
                 <div class="header">
-                  <span data-bind="visible: admin">
-                    {% trans "Repository can be automatically configured" %}
-                  </span>
+                  <span data-bind="visible: admin">{% trans "Repository can be automatically configured" %}</span>
 
-                  <span class="ui red text" data-bind="visible: !admin">
-                    {% trans "Repository must be manually configured" %}
-                  </span>
+                  <span class="ui red text" data-bind="visible: !admin">{% trans "Repository must be manually configured" %}</span>
                 </div>
                 <div class="description">
                   <span data-bind="visible: admin">
@@ -210,9 +195,9 @@
                     {% endblocktrans %}
                   </p>
                   <p class="ui red text" data-bind="visible: !admin">
-                    <a class="ui red mini basic button" href="https://docs.readthedocs.io/page/intro/import-guide.html#manually-import-your-docs" target="_blank">
-                      {% trans "Learn how to manually configure this repository" %}
-                    </a>
+                    <a class="ui red mini basic button"
+                       href="https://docs.readthedocs.io/page/intro/import-guide.html#manually-import-your-docs"
+                       target="_blank">{% trans "Learn how to manually configure this repository" %}</a>
                   </p>
                 </div>
               </div>
@@ -222,9 +207,7 @@
             <div class="item" data-bind="if: has_project">
               <i class="fa-solid fa-plus icon"></i>
               <div class="content">
-                <div class="header">
-                  {% trans "Repository is already configured" %}
-                </div>
+                <div class="header">{% trans "Repository is already configured" %}</div>
                 <div class="description">
                   <p>
                     {% blocktrans trimmed %}
@@ -233,7 +216,9 @@
                   </p>
                   {# TODO this could be a proper project chip and popup card, but would need https://github.com/readthedocs/ext-theme/issues/196 #}
                   <div data-bind="foreach: projects">
-                    <a class="ui basic image label" data-bind="attr: {href: urls.home }" target="_blank">
+                    <a class="ui basic image label"
+                       data-bind="attr: {href: urls.home }"
+                       target="_blank">
                       <img data-bind="if: $parent.avatar_url, attr: {src: $parent.avatar_url}" />
                       <span data-bind="text: name"></span>
                     </a>
@@ -258,9 +243,7 @@
           <input type="hidden" name="remote_repository" data-bind="value: pk" />
           <input type="hidden" name="default_branch" data-bind="value: default_branch" />
 
-          <button class="ui primary button" data-bind="css: {disabled: !admin}">
-            {% trans "Continue" %}
-          </button>
+          <button class="ui primary button" data-bind="css: {disabled: !admin}">{% trans "Continue" %}</button>
         </form>
       </span>
     </div>

--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -169,7 +169,6 @@
               </div>
             </div>
 
-
             {# Does user have admin privileges needed to import? #}
             <div class="item">
               <i class="fa-duotone fa-magic icon" data-bind="css: {red: !admin}"></i>

--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -210,7 +210,7 @@
                     {% endblocktrans %}
                   </p>
                   <p class="ui red text" data-bind="visible: !admin">
-                    <a class="ui red mini basic button" href="https://docs.readthedocs.io/page/intro/import-guide.html#manually-import-your-docs">
+                    <a class="ui red mini basic button" href="https://docs.readthedocs.io/page/intro/import-guide.html#manually-import-your-docs" target="_blank">
                       {% trans "Learn how to manually configure this repository" %}
                     </a>
                   </p>

--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -26,7 +26,7 @@
   {% trans "You don't have any projects configured yet" %}
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
-  <a href="https://docs.readthedocs.io/page/tutorial/" class="ui primary button">
+  <a href="https://docs.readthedocs.io/page/tutorial/" target="_blank" class="ui primary button">
     {% trans "Learn how to get started" %}
   </a>
 {% endblock list_placeholder_text_empty %}
@@ -44,6 +44,7 @@
        data-content="{{ label_link }}"
        aria-label="{{ label_link }}"
        data-bind="event: {mouseover: fetch, focusin: fetch}, attr: {href: url_docs}"
+       target="_blank"
        tabindex="{% if object.has_good_build %}0{% else %}-1{% endif %}">
       <i class="fa-duotone fa-book icon"></i>
     </a>

--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -7,18 +7,17 @@
 {% load projects_tags %}
 
 {% block top_left_menu_items %}
-  <div data-bind="using: FilterView()">
-    {% include "includes/filters/form.html" with fields=filter.form %}
-  </div>
+  <div data-bind="using: FilterView()">{% include "includes/filters/form.html" with fields=filter.form %}</div>
 {% endblock top_left_menu_items %}
 
 {% block create_button %}
   {% url "projects_import" as create_url %}
   {% trans "Add project" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}{% endblock %}
+{% block list_placeholder_icon_class %}
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header_filtered %}
   {% trans "No matching projects found" %}
 {% endblock list_placeholder_header_filtered %}
@@ -26,80 +25,78 @@
   {% trans "You don't have any projects configured yet" %}
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
-  <a href="https://docs.readthedocs.io/page/tutorial/" target="_blank" class="ui primary button">
-    {% trans "Learn how to get started" %}
-  </a>
+  <a href="https://docs.readthedocs.io/page/tutorial/"
+     target="_blank"
+     class="ui primary button">{% trans "Learn how to get started" %}</a>
 {% endblock list_placeholder_text_empty %}
 
 {% block list_item_start %}
   <tr data-bind="using: ProjectListItemView({id: {{ object.id }}, url: '{% url "project-detail" object.pk %}'})">
-{% endblock list_item_start %}
+  {% endblock list_item_start %}
 
-{% block list_item_right_menu %}
-  <div class="ui small icon buttons">
-    {% blocktrans trimmed with project=object.name asvar label_link %}
-      View documentation for project {{ project }}
-    {% endblocktrans %}
-    <a class="ui {% if not object.has_good_build %} disabled{% endif %} button"
-       data-content="{{ label_link }}"
-       aria-label="{{ label_link }}"
-       data-bind="event: {mouseover: fetch, focusin: fetch}, attr: {href: url_docs}"
-       target="_blank"
-       tabindex="{% if object.has_good_build %}0{% else %}-1{% endif %}">
-      <i class="fa-duotone fa-book icon"></i>
-    </a>
+  {% block list_item_right_menu %}
+    <div class="ui small icon buttons">
+      {% blocktrans trimmed with project=object.name asvar label_link %}
+        View documentation for project {{ project }}
+      {% endblocktrans %}
+      <a class="ui {% if not object.has_good_build %}disabled{% endif %} button"
+         data-content="{{ label_link }}"
+         aria-label="{{ label_link }}"
+         data-bind="event: {mouseover: fetch, focusin: fetch}, attr: {href: url_docs}"
+         target="_blank"
+         tabindex="{% if object.has_good_build %}0{% else %}-1{% endif %}">
+        <i class="fa-duotone fa-book icon"></i>
+      </a>
 
-    {% if request.user|is_admin:object %}
-      <button class="ui dropdown button">
-        <i class="fa-solid fa-ellipsis icon"></i>
-        <div class="menu">
-          <div class="header">{% trans "Admin" %}</div>
-          <a class="item" href="{% url "projects_edit" object.slug %}">
-            <i class="fa-duotone fa-wrench icon"></i>
-            {% trans "Configure project" %}
-          </a>
-        </div>
-      </button>
-    {% else %}
-      <button class="ui disabled dropdown button">
-        <i class="fa-solid fa-ellipsis icon"></i>
-      </button>
-    {% endif %}
+      {% if request.user|is_admin:object %}
+        <button class="ui dropdown button">
+          <i class="fa-solid fa-ellipsis icon"></i>
+          <div class="menu">
+            <div class="header">{% trans "Admin" %}</div>
+            <a class="item" href="{% url "projects_edit" object.slug %}">
+              <i class="fa-duotone fa-wrench icon"></i>
+              {% trans "Configure project" %}
+            </a>
+          </div>
+        </button>
+      {% else %}
+        <button class="ui disabled dropdown button">
+          <i class="fa-solid fa-ellipsis icon"></i>
+        </button>
+      {% endif %}
 
-  </div>
-{% endblock list_item_right_menu %}
+    </div>
+  {% endblock list_item_right_menu %}
 
-{% block list_item_image %}
-  {% include "projects/includes/project_image.html" with project=object %}
-{% endblock list_item_image %}
+  {% block list_item_image %}
+    {% include "projects/includes/project_image.html" with project=object %}
+  {% endblock list_item_image %}
 
-{% block list_item_header %}
-  <a class="" href="{% url "projects_detail" object.slug %}">
-    {{ object.name }}
-  </a>
-  <div class="sub header">
+  {% block list_item_header %}
+    <a href="{% url "projects_detail" object.slug %}">{{ object.name }}</a>
+    <div class="sub header">
+      {% if object.has_good_build %}
+        {% with build=object.get_latest_build %}
+          <time data-content="{{ build.date }}">
+            {# Translators: this will read like "Last built 1 year, 5 months ago" #}
+            {% blocktrans with time_since=build.date|naturaltime trimmed %}
+              Last built {{ time_since }}
+            {% endblocktrans %}
+          </time>
+        {% endwith %}
+      {% else %}
+        {% trans "Not built yet" %}
+      {% endif %}
+    </div>
+  {% endblock list_item_header %}
+
+  {% block list_item_meta %}
+  {% endblock list_item_meta %}
+
+  {% block list_item_extra_items %}
     {% if object.has_good_build %}
       {% with build=object.get_latest_build %}
-        <time data-content="{{ build.date }}">
-          {# Translators: this will read like "Last built 1 year, 5 months ago" #}
-          {% blocktrans with time_since=build.date|naturaltime trimmed %}
-            Last built {{ time_since }}
-          {% endblocktrans %}
-        </time>
+        {% include "includes/elements/chips/build.html" with build=build %}
       {% endwith %}
-    {% else %}
-      {% trans "Not built yet" %}
     {% endif %}
-  </div>
-{% endblock list_item_header %}
-
-{% block list_item_meta %}
-{% endblock list_item_meta %}
-
-{% block list_item_extra_items %}
-  {% if object.has_good_build %}
-    {% with build=object.get_latest_build %}
-      {% include "includes/elements/chips/build.html" with build=build %}
-    {% endwith %}
-  {% endif %}
-{% endblock %}
+  {% endblock list_item_extra_items %}

--- a/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
+++ b/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
@@ -38,7 +38,8 @@
 {% block list_placeholder_text %}
   <a class="ui button"
      href="https://docs.readthedocs.io/en/stable/guides/connecting-git-account.html"
-     aria-label="{% trans "Learn more about this feature in our documentation pages" %}">{% trans "Learn more" %}</a>
+     aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
+     target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_menu %}

--- a/readthedocsext/theme/templates/support/index.html
+++ b/readthedocsext/theme/templates/support/index.html
@@ -3,10 +3,9 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-
 {% block title %}
   {% trans "Support request" %}
-{% endblock %}
+{% endblock title %}
 
 {% block content %}
   <h1 class="ui large heading">{% trans "Support request" %}</h1>
@@ -75,7 +74,7 @@
       </p>
 
       <form class="ui form"
-            method="POST"
+            method="post"
             name="support-request"
             action="{{ SUPPORT_FORM_ENDPOINT }}"
             enctype="multipart/form-data"
@@ -89,4 +88,4 @@
       </form>
     {% endif %}
   {% endblock support_form %}
-{% endblock %}
+{% endblock content %}

--- a/readthedocsext/theme/templates/support/index.html
+++ b/readthedocsext/theme/templates/support/index.html
@@ -4,7 +4,9 @@
 {% load crispy_forms_tags %}
 
 
-{% block title %}{% trans "Support request" %}{% endblock %}
+{% block title %}
+  {% trans "Support request" %}
+{% endblock %}
 
 {% block content %}
   <h1 class="ui large heading">{% trans "Support request" %}</h1>
@@ -18,14 +20,16 @@
         or let us know if there is an issue with the service.
       </p>
       <p>
-        You can always check out <a href="http://docs.readthedocs.org/en/latest/business/index.html" target="_blank">our documentation</a> as well.
+        You can always check out <a href="https://docs.readthedocs.org/en/latest/business/index.html"
+    target="_blank">our documentation</a> as well.
         It contains a number of answers to common questions and helps you understand the features on our site a bit more.
       </p>
     {% else %}
       <h2 id="usage-questions">Usage questions</h2>
 
       <p>
-        If you have questions about how to use Read the Docs, or have an issue that isn't related to a bug, <a href="http://stackoverflow.com/questions/tagged/read-the-docs" target="_blank">Stack Overflow</a> is the best place to ask. Tag questions with <span class="pre">read-the-docs</span> so other folks can find them easily.
+        If you have questions about how to use Read the Docs, or have an issue that isn't related to a bug, <a href="https://stackoverflow.com/questions/tagged/read-the-docs"
+    target="_blank">Stack Overflow</a> is the best place to ask. Tag questions with <span class="pre">read-the-docs</span> so other folks can find them easily.
       </p>
 
       <p>
@@ -38,7 +42,8 @@
       <p>
         If you have an issue with the actual functioning of the site,
         you can file bug reports on our <a href="https://github.com/readthedocs/readthedocs.org/issues">GitHub issue tracker</a>.
-        You can also <a href="http://docs.readthedocs.io/page/contribute.html" target="_blank">contribute</a> to Read the Docs,
+        You can also <a href="https://docs.readthedocs.io/page/contribute.html"
+    target="_blank">contribute</a> to Read the Docs,
         as the code is open source.
       </p>
 
@@ -60,7 +65,7 @@
 
     {% if not SUPPORT_FORM_ENDPOINT %}
       <p>
-        Please send an email to <a href="mailto:{{SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a>
+        Please send an email to <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a>
         and we will get back to you as soon as possible.
       </p>
     {% else %}
@@ -69,17 +74,18 @@
         and we will get back to you as soon as possible.
       </p>
 
-      <form
-        class="ui form"
-        method="POST"
-        name="support-request"
-        action="{{ SUPPORT_FORM_ENDPOINT }}"
-        enctype="multipart/form-data"
-        accept-charset="utf-8">
+      <form class="ui form"
+            method="POST"
+            name="support-request"
+            action="{{ SUPPORT_FORM_ENDPOINT }}"
+            enctype="multipart/form-data"
+            accept-charset="utf-8">
 
         {{ form|crispy }}
 
-        <input class="ui primary button" type="submit" value="Submit support request" />
+        <input class="ui primary button"
+               type="submit"
+               value="Submit support request" />
       </form>
     {% endif %}
   {% endblock support_form %}

--- a/readthedocsext/theme/templates/support/index.html
+++ b/readthedocsext/theme/templates/support/index.html
@@ -38,7 +38,7 @@
       <p>
         If you have an issue with the actual functioning of the site,
         you can file bug reports on our <a href="https://github.com/readthedocs/readthedocs.org/issues">GitHub issue tracker</a>.
-        You can also <a href="http://docs.readthedocs.io/page/contribute.html">contribute</a> to Read the Docs,
+        You can also <a href="http://docs.readthedocs.io/page/contribute.html" target="_blank">contribute</a> to Read the Docs,
         as the code is open source.
       </p>
 

--- a/readthedocsext/theme/templates/support/success.html
+++ b/readthedocsext/theme/templates/support/success.html
@@ -4,7 +4,7 @@
 
 {% block title %}
   {% trans "Support request submitted" %}
-{% endblock %}
+{% endblock title %}
 
 {% block support_form %}
   <div class="ui positive message">

--- a/readthedocsext/theme/templates/support/success.html
+++ b/readthedocsext/theme/templates/support/success.html
@@ -2,7 +2,9 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Support request submitted" %}{% endblock %}
+{% block title %}
+  {% trans "Support request submitted" %}
+{% endblock %}
 
 {% block support_form %}
   <div class="ui positive message">

--- a/readthedocsext/theme/templates/support/success.html
+++ b/readthedocsext/theme/templates/support/success.html
@@ -21,7 +21,7 @@
   <p>
     {% blocktrans trimmed with url="https://docs.readthedocs.io/en/latest/index.html#step-by-step-guides" %}
       While you are waiting for a response,
-      you might want to browse <a href="{{ url }}">our guides</a>,
+      you might want to browse <a href="{{ url }}" target="_blank">our guides</a>,
       which provide step-by-step solutions to common support questions.
     {% endblocktrans %}
   </p>


### PR DESCRIPTION
This is based on a feedback we received from a user.
As a general rule, we should use `target=_blank` for all the links that go
_outside_ the dashboard.

**There is a lot of lint changes**. I split the work into different commits to make it easier to review.