### PR TITLE
Tune djlint configuration

### DIFF
--- a/.djlint_rules.yaml
+++ b/.djlint_rules.yaml
@@ -1,0 +1,6 @@
+- rule:
+    name: T901
+    message: Wildcard load, use load X from Y
+    flags: re.DOTALL
+    patterns:
+      - '{% load \w+(?! from \w+) %}'

--- a/.djlintrc
+++ b/.djlintrc
@@ -1,5 +1,6 @@
 {
   "indent": "2",
   "preserve_blank_lines": true,
-  "ignore": "H006"
+  "ignore": "H006",
+  "max_line_length": 80,
 }

--- a/.djlintrc
+++ b/.djlintrc
@@ -2,5 +2,5 @@
   "indent": "2",
   "preserve_blank_lines": true,
   "ignore": "H006",
-  "max_line_length": 80,
+  "max_line_length": 80
 }


### PR DESCRIPTION
Use max_line_length=80, this only controls when attributes/blocks are
wrapped. This setting is why nicer block formatting is sometimes
condensed down to single lines.

The lint rule is for catching wildcard load imports.