### PR TITLE
Proxito: add template for password protected docs

### DIFF
--- a/readthedocsext/theme/templates/acl/shared_password_required.html
+++ b/readthedocsext/theme/templates/acl/shared_password_required.html
@@ -23,6 +23,8 @@
   </form>
 
   <p>
-    {% blocktrans %}Already have an account? Then please <a href="//{{ PRODUCTION_DOMAIN }}/accounts/login/">log in</a>.{% endblocktrans %}
+    {% blocktrans trimmed with domain=PRODUCTION_DOMAIN %}
+      Already have an account? Then please <a href="https://{{ domain }}/accounts/login/">log in</a>.
+    {% endblocktrans %}
   </p>
 {% endblock content %}

--- a/readthedocsext/theme/templates/acl/shared_password_required.html
+++ b/readthedocsext/theme/templates/acl/shared_password_required.html
@@ -1,0 +1,28 @@
+{% extends "proxito/base.html" %}
+{% load trans blocktrans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block title %}
+  {% trans "Authentication required" %}
+{% endblock title %}
+
+{% block content %}
+  <h1>{% trans "Authentication required" %}</h1>
+
+  <p>
+    {% blocktrans with project_name=project.name %}
+    You need special requirements to access "{{ project_name }}" project documentation.
+    Please, provide a valid password to see the docs.
+    {% endblocktrans %}
+  </p>
+
+  <form class="ui form" method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button class="ui primary button" type="submit">{% trans "Log in" %}</button>
+  </form>
+
+  <p>
+    {% blocktrans %}Already have an account? Then please <a href="//{{ PRODUCTION_DOMAIN }}/accounts/login/">log in</a>.{% endblocktrans %}
+  </p>
+{% endblock content %}

--- a/readthedocsext/theme/templates/proxito/base.html
+++ b/readthedocsext/theme/templates/proxito/base.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% load static from static %}
+
+{% comment %}
+This is for page shown in documentation pages, not the dashboard.
+{% endcomment %}
+
+{% block header %}
+  <div class="ui basic fitted attached segment">
+    <div class="ui container">
+      <div class="ui middle aligned grid">
+        <div class="four wide computer five wide tablet eleven wide mobile left aligned column">
+          <div class="ui horizontally fitted basic segment">
+            <a href="https://{{ PRODUCTION_DOMAIN }}/"
+               aria-label="Read the Docs homepage">
+              <img class="ui image"
+                   src="{% static 'readthedocsext/theme/images/logo-wordmark-dark.svg' %}"
+                   width="220"
+                   alt="Read the Docs logo" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock header %}
+
+{% block footer %}
+{% endblock footer %}


### PR DESCRIPTION
This is a simple placeholder until we have
the base templates for proxito ready.

We need this template, so tests from https://github.com/readthedocs/readthedocs-corporate/pull/1807 pass.

Ref https://github.com/readthedocs/ext-theme/issues/393

![Screenshot 2024-08-19 at 16-49-03 Authentication required - Read the Docs](https://github.com/user-attachments/assets/05152320-1fd1-4f0f-86bd-df937ae91575)
