### PR TITLE
Domain: show notifications for configuration

### DIFF
--- a/readthedocsext/theme/templates/projects/domain_form.html
+++ b/readthedocsext/theme/templates/projects/domain_form.html
@@ -1,7 +1,7 @@
 {% extends "projects/domain_list.html" %}
 
-{% load i18n %}
-{% load crispy_forms_tags %}
+{% load trans blocktrans from i18n %}
+{% load crispy from crispy_forms_tags %}
 
 {% block project_edit_content_subheader %}
   {% if domain %}
@@ -19,6 +19,25 @@
     {% url 'projects_domains_create' project.slug as action_url %}
     {% trans "Add domain" as button_text %}
   {% endif %}
+
+  {% if domain.domainssl %}
+    <div class="ui info message">
+      {% blocktrans trimmed with cname_target=domain.domainssl.cname_target %}
+        To configure this domain add a CNAME record in your DNS pointing
+        your custom domain to <code>{{ cname_target }}</code>.
+      {% endblocktrans %}
+    </div>
+
+    {% if not domain.skip_validation and not domain.is_valid and domain.validation_process_expired %}
+      <div class="ui warning message">
+        {% blocktrans trimmed %}
+          The validation process period has ended.
+          Save the domain to restart the process.
+        {% endblocktrans %}
+      </div>
+    {% endif %}
+  {% endif %}
+
   <form class="ui form" method="post" action="{{ action_url }}">
     {% csrf_token %}
     {{ form|crispy }}
@@ -32,13 +51,12 @@
             <div>
               {{ domain.domainssl.status }}
               <div class="ui warning message">
-                {% trans 'Did you setup a CNAME record in DNS pointing at "readthedocs.io"?' %}
+                {% trans "Did you setup a CNAME record in DNS pointing at \"readthedocs.io\"?" %}
               </div>
             </div>
           </div>
 
-          {% if domain.domainssl.status == 'pending_validation' or True %}
-          {% endif %}
+          {% if domain.domainssl.status == 'pending_validation' or True %}{% endif %}
         </div>
       {% endif %}
     {% endblock domain_ssl %}
@@ -51,4 +69,4 @@
       </div>
     {% endif %}
   </form>
-{% endblock %}
+{% endblock project_edit_content %}

--- a/readthedocsext/theme/templates/projects/domain_form.html
+++ b/readthedocsext/theme/templates/projects/domain_form.html
@@ -21,13 +21,16 @@
   {% endif %}
 
   {% if domain.domainssl %}
+    <p>
+      {% trans "To configure this domain add a CNAME record in your DNS pointing your custom domain to this target." %}
+    </p>
+
     <div class="ui segment">
       <div class="ui list">
         <div class="item">
           <div class="content">
             <div class="header">{% trans "CNAME target" %}</div>
             <div class="description">
-              {% trans "To configure this domain add a CNAME record in your DNS pointing your custom domain to this target." %}
               <div class="ui fluid action input">
                 <input type="text" readonly value="{{ domain.domainssl.cname_target }}" />
                 <button class="ui right icon button"

--- a/readthedocsext/theme/templates/projects/domain_form.html
+++ b/readthedocsext/theme/templates/projects/domain_form.html
@@ -21,11 +21,25 @@
   {% endif %}
 
   {% if domain.domainssl %}
-    <div class="ui info message">
-      {% blocktrans trimmed with cname_target=domain.domainssl.cname_target %}
-        To configure this domain add a CNAME record in your DNS pointing
-        your custom domain to <code>{{ cname_target }}</code>.
-      {% endblocktrans %}
+    <div class="ui segment">
+      <div class="ui list">
+        <div class="item">
+          <div class="content">
+            <div class="header">{% trans "CNAME target" %}</div>
+            <div class="description">
+              {% trans "To configure this domain add a CNAME record in your DNS pointing your custom domain to this target." %}
+              <div class="ui fluid action input">
+                <input type="text" readonly value="{{ domain.domainssl.cname_target }}" />
+                <button class="ui right icon button"
+                        data-clipboard-text="{{ domain.domainssl.cname_target }}"
+                        data-content="{% trans "Copied!" %}">
+                  <i class="fas fa-copy icon"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     {% if not domain.skip_validation and not domain.is_valid and domain.validation_process_expired %}


### PR DESCRIPTION
This is the initial work required -- not tuned.

- Bring back the notification explaining that a CNAME has to be added in the DNS
- Bring back the notification about the validation process ended

My goal here is to give users the information they need to setup the domain. However, I think this page could get benefit from some extra work/style. Baby steps.

![Screenshot_2024-08-22_18-38-48](https://github.com/user-attachments/assets/c4b13576-df3f-475d-be6c-42335f288e89)


Closes #449