### PR TITLE
Use proxito base templates for Allauth account/socialaccount templates

### DIFF
--- a/readthedocsext/theme/templates/account/email_confirm.html
+++ b/readthedocsext/theme/templates/account/email_confirm.html
@@ -1,17 +1,17 @@
 {% extends "account/base_entrance.html" %}
 
-{% load i18n %}
-{% load account %}
+{% load blocktrans trans from i18n %}
+{% load user_display from account %}
 
-{% block head_title %}{% trans "Verify email" %}{% endblock %}
+{% block head_title %}
+  {% trans "Verify email" %}
+{% endblock head_title %}
+{% block content_title_text %}
+  <i class="fad fa-envelope icon"></i>
+  {% trans "Verify email" %}
+{% endblock content_title_text %}
 
-{% block content %}
-
-  <h1 class="ui medium header">
-    <i class="fad fa-envelope icon"></i>
-    {% trans "Verify email" %}
-  </h1>
-
+{% block content_body %}
   {% if confirmation %}
 
     {% user_display confirmation.email_address.user as user_display %}
@@ -23,9 +23,12 @@
       {% endblocktrans %}
     </p>
 
-    <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+    <form method="post"
+          action="{% url 'account_confirm_email' confirmation.key %}">
       {% csrf_token %}
-      <button class="ui primary button" type="submit">{% trans 'Verify email' %}</button>
+      <button class="ui primary button" type="submit">
+        {% trans "Verify email" %}
+      </button>
     </form>
 
   {% else %}
@@ -40,4 +43,4 @@
     </p>
 
   {% endif %}
-{% endblock %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -8,109 +8,108 @@
   {% trans "Log in" %}
 {% endblock head_title %}
 
-{% block content %}
-  <div class="ui stackable padded grid">
+{% block content_title_text %}
+  {% if is_from_cas_login %}
+    {% trans "Log in to view this documentation" %}
+  {% else %}
+    {% trans "Log in to continue" %}
+  {% endif %}
+{% endblock content_title_text %}
 
-    <div class="sixteen wide computer sixteen wide tablet sixteen wide mobile column">
-      {% get_providers as socialaccount_providers %}
+{% block content_text %}
+  {% get_providers as socialaccount_providers %}
 
-      <div class="ui medium header">
-        {% block authentication_header %}
-          {% if is_from_cas_login %}
-            {% trans "Log in to view this documentation" %}
-          {% else %}
-            {% trans "Log in to continue" %}
-          {% endif %}
-        {% endblock authentication_header %}
-      </div>
-
-      <div class="ui small stackable teal secondary menu"
-           data-bind="semanticui: {tabs: {history: true, autoTabActivation: false}}">
-
-        <div class="header item">
+  <div class="ui basic horizontally fitted segment">
+    <div class="ui form">
+      <div class="field">
+        <label>
           {% block authentication_header_text %}
             {% trans "Log in using:" %}
           {% endblock authentication_header_text %}
-        </div>
+        </label>
+      </div>
+    </div>
 
-        <a class="item" data-tab="vcs">
-          <i class="fas fa-cloud icon"></i>
-          {% block authentication_vcs_text %}
-            {% trans "Connected account" %}
-          {% endblock authentication_vcs_text %}
+    <div class="ui small stackable teal centered fluid wrapping menu"
+         data-bind="semanticui: {tabs: {history: true, autoTabActivation: false}}">
+
+      <a class="item" data-tab="vcs">
+        <i class="fas fa-cloud icon"></i>
+        {% block authentication_vcs_text %}
+          {% trans "Connected account" %}
+        {% endblock authentication_vcs_text %}
+      </a>
+
+      {# If allowed providers is given, disable the email menu item #}
+      <a class="{% if allowed_providers %}disabled{% endif %} item"
+         data-tab="email">
+        <i class="fas fa-envelope icon"></i>
+        {% block authentication_email_text %}
+          {% trans "Email" %}
+        {% endblock authentication_email_text %}
+      </a>
+
+      {% if USE_ORGANIZATIONS %}
+        <a class="item"
+          {# Link to the old dashboard, since the new dashboard doesn't work for granting access to docs pages yet #}
+          href="https://readthedocs.com{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
+          <i class="fas fa-shield-alt icon"></i>
+          {% trans "Single sign-on" %}
         </a>
+      {% endif %}
 
-        {# If allowed providers is given, disable the email menu item #}
-        <a class="{% if allowed_providers %}disabled{% endif %} item"
-           data-tab="email">
-          <i class="fas fa-envelope icon"></i>
-          {% block authentication_email_text %}
-            {% trans "Email" %}
-          {% endblock authentication_email_text %}
+      {% if project_password_url %}
+        <a class="item" href="{{ project_password_url }}">
+          <i class="fas fa-lock icon"></i>
+          {% block authentication_password_text %}
+            {% trans "Password" %}
+          {% endblock authentication_password_text %}
         </a>
-
-        {% if USE_ORGANIZATIONS %}
-          <a class="item"
-            {# Link to the old dashboard, since the new dashboard doesn't work for granting access to docs pages yet #}
-            href="https://readthedocs.com{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
-            <i class="fas fa-shield-alt icon"></i>
-            {% trans "Single sign-on" %}
-          </a>
-        {% endif %}
-
-        {% if project_password_url %}
-          <a class="item" href="{{ project_password_url }}">
-            <i class="fas fa-lock icon"></i>
-            {% block authentication_password_text %}
-              {% trans "Password" %}
-            {% endblock authentication_password_text %}
-          </a>
-        {% endif %}
-      </div>
-
-      <div class="ui basic center aligned tab segment" data-tab="vcs">
-        <div class="ui relaxed list">
-          {% block authentication_vcs %}
-            {# Translators: this will read "Log in with GitHub", where "log in" is a verb #}
-            {% blocktrans asvar text_log_in %}Log in using{% endblocktrans %}
-            {% include "socialaccount/snippets/provider_list.html" with process="login" verbiage=text_log_in %}
-          {% endblock authentication_vcs %}
-        </div>
-      </div>
-      <div class="ui basic vertically fitted tab segment" data-tab="email">
-        {% block authentication_email %}
-          <p class="ui center aligned vertically fitted small basic fluid segment">
-            {# The /email addition is to route to the tab page on the login/signup forms, using the tab module history setting #}
-            {% blocktrans trimmed %}
-              Need an account? <a href="{{ signup_url }}#/email">Sign up</a> first.
-            {% endblocktrans %}
-          </p>
-
-          <form class="ui form"
-                method="post"
-                action="{% url "account_login" %}#/email">
-            {% csrf_token %}
-            {{ form|crispy }}
-            {% if redirect_field_value %}
-              <input type="hidden"
-                     name="{{ redirect_field_name }}"
-                     value="{{ redirect_field_value }}" />
-            {% endif %}
-
-            <div class="ui stackable relaxed text menu">
-              <a class="item" href="{% url 'account_reset_password' %}">{% trans "Forgot your password?" %}</a>
-              <div class="right menu">
-                <button class="ui primary button" type="submit">{% trans "Log in" %}</button>
-              </div>
-            </div>
-
-          </form>
-        {% endblock authentication_email %}
-      </div>
-
-      {% block authentication_extra %}
-      {% endblock authentication_extra %}
-
+      {% endif %}
     </div>
   </div>
-{% endblock content %}
+
+  <div class="ui basic center aligned tab segment" data-tab="vcs">
+    <div class="ui relaxed list">
+      {% block authentication_vcs %}
+        {# Translators: this will read "Log in with GitHub", where "log in" is a verb #}
+        {% blocktrans asvar text_log_in %}Log in using{% endblocktrans %}
+        {% include "socialaccount/snippets/provider_list.html" with process="login" verbiage=text_log_in %}
+      {% endblock authentication_vcs %}
+    </div>
+  </div>
+  <div class="ui basic vertically fitted tab segment" data-tab="email">
+    {% block authentication_email %}
+      <p class="ui center aligned vertically fitted small basic fluid segment">
+        {# The /email addition is to route to the tab page on the login/signup forms, using the tab module history setting #}
+        {% blocktrans trimmed %}
+          Need an account? <a href="{{ signup_url }}#/email">Sign up</a> first.
+        {% endblocktrans %}
+      </p>
+
+      <form class="ui form"
+            method="post"
+            action="{% url "account_login" %}#/email">
+        {% csrf_token %}
+        {{ form|crispy }}
+        {% if redirect_field_value %}
+          <input type="hidden"
+                 name="{{ redirect_field_name }}"
+                 value="{{ redirect_field_value }}" />
+        {% endif %}
+
+        <div class="ui stackable relaxed text menu">
+          <a class="item" href="{% url 'account_reset_password' %}">{% trans "Forgot your password?" %}</a>
+          <div class="right menu">
+            <button class="ui primary button" type="submit">{% trans "Log in" %}</button>
+          </div>
+        </div>
+
+      </form>
+    {% endblock authentication_email %}
+  </div>
+
+  {% block authentication_extra %}
+  {% endblock authentication_extra %}
+
+{% endblock content_text %}

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -16,7 +16,7 @@
   {% endif %}
 {% endblock content_title_text %}
 
-{% block content_text %}
+{% block content_body %}
   {% get_providers as socialaccount_providers %}
 
   <div class="ui basic horizontally fitted segment">
@@ -112,4 +112,4 @@
   {% block authentication_extra %}
   {% endblock authentication_extra %}
 
-{% endblock content_text %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/password_reset.html
+++ b/readthedocsext/theme/templates/account/password_reset.html
@@ -1,18 +1,18 @@
 {% extends "account/base_entrance.html" %}
 
-{% load i18n %}
-{% load account %}
-{% load crispy_forms_tags %}
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
 
-{% block head_title %}{% trans "Password reset" %}{% endblock %}
+{% block head_title %}
+  {% trans "Password reset" %}
+{% endblock head_title %}
 
-{% block content %}
+{% block content_title_text %}
+  <i class="fad fa-envelope icon"></i>
+  {% trans "Password reset" %}
+{% endblock content_title_text %}
 
-  <h1 class="ui medium header">
-    <i class="fad fa-envelope icon"></i>
-    {% trans "Password reset" %}
-  </h1>
-
+{% block content_body %}
   {% if user.is_authenticated %}
     {% include "account/snippets/already_logged_in.html" %}
   {% endif %}
@@ -25,13 +25,10 @@
   </p>
 
   <form class="ui form"
-        method="POST"
+        method="post"
         action="{% url 'account_reset_password' %}">
     {% csrf_token %}
     {{ form|crispy }}
-    <button class="ui primary button" type="submit">
-      {% trans 'Reset' %}
-    </button>
+    <button class="ui primary button" type="submit">{% trans "Reset" %}</button>
   </form>
-
-{% endblock %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/password_reset_done.html
+++ b/readthedocsext/theme/templates/account/password_reset_done.html
@@ -1,0 +1,22 @@
+{% extends "account/base_entrance.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block head_title %}
+  {% trans "Password reset" %}
+{% endblock head_title %}
+{% block content_title_text %}
+  {% trans "Password reset" %}
+{% endblock content_title_text %}
+
+{% block content_body %}
+  <p>
+    {% url "support" as url_support %}
+    {% blocktrans trimmed with url_support=url_support %}
+      If there is an existing account with the provided email address, we will
+      send an email with directions to reset your account password. If you
+      don't receive this, check your email spam folder or
+      <a href="{{ url_support }}">contact support for more help</a>.
+    {% endblocktrans %}
+  </p>
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/password_reset_from_key.html
+++ b/readthedocsext/theme/templates/account/password_reset_from_key.html
@@ -1,0 +1,42 @@
+{% extends "account/base_entrance.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block head_title %}
+  {% trans "Change Password" %}
+{% endblock head_title %}
+{% block content_title_text %}
+  {% if token_fail %}
+    {% trans "Error: expired link" %}
+  {% else %}
+    {% trans "Change password" %}
+  {% endif %}
+{% endblock content_title_text %}
+
+{% block content_body %}
+  {% if token_fail %}
+    <p class="ui error message">
+      {% url 'account_reset_password' as url_reset %}
+      {% blocktrans trimmed with url_reset=url_reset %}
+        The password reset link was invalid, possibly because it has already been used.
+        Please request a <a href="{{ url_reset }}">password reset</a> again.
+      {% endblocktrans %}
+    </p>
+  {% else %}
+    <form class="ui form" method="post" action="{{ action_url }}">
+      {% csrf_token %}
+      {{ form|crispy }}
+      {{ redirect_field }}
+
+      <div class="ui stackable relaxed text menu">
+        <div class="right menu">
+          <button class="ui primary button" type="submit">
+            {% trans "Change password" %}
+          </button>
+        </div>
+      </div>
+
+    </form>
+  {% endif %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/password_reset_from_key_done.html
+++ b/readthedocsext/theme/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,14 @@
+{% extends "account/base_entrance.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block head_title %}
+  {% trans "Password updated" %}
+{% endblock head_title %}
+{% block content_title_text %}
+  {% trans "Password updated" %}
+{% endblock content_title_text %}
+
+{% block content_body %}
+  {% trans "Your password has been updated, you can now log in using your new password." %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/saml.html
+++ b/readthedocsext/theme/templates/account/saml.html
@@ -1,18 +1,20 @@
 {% extends "socialaccount/base_entrance.html" %}
 
-{% load crispy_forms_tags %}
-{% load i18n %}
+{% load crispy from crispy_forms_tags %}
+{% load blocktrans trans from i18n %}
 
 {% block head_title %}
   {% trans "Log in with single sign-on" %}
 {% endblock head_title %}
+{% block content_title_text %}
+  {% trans "Continue with SAML single sign-on" %}
+{% endblock content_title_text %}
 
-{% block content %}
-  <h1 clas="ui medium header">{% trans "Continue with SAML single sign-on" %}</h1>
+{% block content_body %}
   <form class="ui form" method="post" action="{% url "saml_resolve_login" %}">
     {% csrf_token %}
     {{ form|crispy }}
     {{ redirect_field }}
     <button class="ui button" type="submit">{% trans "Continue" %}</button>
   </form>
-{% endblock content %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/allauth/layouts/entrance.html
+++ b/readthedocsext/theme/templates/allauth/layouts/entrance.html
@@ -1,0 +1,30 @@
+{% extends "proxito/base.html" %}
+
+{% load static from static %}
+{% load trans from i18n %}
+
+{% block content-wrapper %}
+  {# This is overriding the normal base.html content-wrapper, #}
+  {# so we need to include notifications here so they're displayed. #}
+  {% block notifications %}
+    {{ block.super }}
+  {% endblock notifications %}
+
+  {{ block.super }}
+{% endblock content-wrapper %}
+
+{% block content_extra_text %}
+  {% block content_extra_logo %}
+    <div class="right floated">
+      {# djlint: off D018 #}
+      <a href="//{{ PRODUCTION_DOMAIN }}/"
+         aria-label="{% trans "Read the Docs" %}">
+        <img class="ui middle aligned image"
+             src="{% static 'readthedocsext/theme/images/logo-wordmark-dark.svg' %}"
+             width="140"
+             alt="{% trans "Read the Docs logo" %}" />
+      </a>
+      {# djlint: on #}
+    </div>
+  {% endblock content_extra_logo %}
+{% endblock content_extra_text %}

--- a/readthedocsext/theme/templates/allauth/layouts/manage.html
+++ b/readthedocsext/theme/templates/allauth/layouts/manage.html
@@ -1,0 +1,1 @@
+{% extends "allauth/layouts/base.html" %}

--- a/readthedocsext/theme/templates/errors/proxito/base.html
+++ b/readthedocsext/theme/templates/errors/proxito/base.html
@@ -3,6 +3,17 @@
 {% load static from static %}
 {% load trans from i18n %}
 
+{# We still use our CSS on user hosted content #}
+{% block head_links %}
+  {{ block.super }}
+{% endblock head_links %}
+
+{# Remove unwanted JS from user hosted content #}
+{% block head_scripts %}
+{% endblock head_scripts %}
+{% block body_scripts %}
+{% endblock body_scripts %}
+
 {% block content_title_text %}
   {% block error_title %}
     <span class="ui grey text">

--- a/readthedocsext/theme/templates/errors/proxito/base.html
+++ b/readthedocsext/theme/templates/errors/proxito/base.html
@@ -23,7 +23,7 @@
   {% endblock error_title %}
 {% endblock content_title_text %}
 
-{% block content_text %}
+{% block content_description %}
   <div class="meta">
     {# djlint: off D018 #}
     <a href="/">{{ request.get_host }}</a>
@@ -36,7 +36,7 @@
     {% block error_content_help %}
     {% endblock error_content_help %}
   </div>
-{% endblock content_text %}
+{% endblock content_description %}
 
 {% block content_extra_text %}
   {% block content_extra_link %}

--- a/readthedocsext/theme/templates/proxito/base.html
+++ b/readthedocsext/theme/templates/proxito/base.html
@@ -43,8 +43,12 @@
                 </div>
               {% endblock content_title %}
 
-              {% block content_text %}
-              {% endblock content_text %}
+              {% block content_description %}
+                <div class="description">
+                  {% block content_body %}
+                  {% endblock content_body %}
+                </div>
+              {% endblock content_description %}
 
             {% endblock content %}
           </div>

--- a/readthedocsext/theme/templates/proxito/base.html
+++ b/readthedocsext/theme/templates/proxito/base.html
@@ -12,13 +12,15 @@
 {% block head_meta %}
 {% endblock head_meta %}
 
+{# Use our base CSS/JS, though we should remove unwanted files from user hosted content #}
 {% block head_links %}
   {{ block.super }}
 {% endblock head_links %}
-
 {% block head_scripts %}
+  {{ block.super }}
 {% endblock head_scripts %}
 {% block body_scripts %}
+  {{ block.super }}
 {% endblock body_scripts %}
 
 {% block header %}


### PR DESCRIPTION
This uses the entrance/manage base pattern from Allauth to provide two base templates:

 - Any template using base_entrance.html will use the Proxito style base template, which drops the header/footer from the application. CSS/JS is still used however
 - An application styled base_manage.html for pages that are more clearly account management templates

Some missing templates were not styled and were adapted from Allauth templates.

- Fixes #435
- Fixes #427
- Refs #462