### PR TITLE
Add templates for Allauth MFA

### DIFF
--- a/readthedocsext/theme/templates/account/base_reauthenticate.html
+++ b/readthedocsext/theme/templates/account/base_reauthenticate.html
@@ -1,0 +1,26 @@
+{% extends "account/base_entrance.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block head_title %}
+  {% trans "Confirm access" %}
+{% endblock head_title %}
+{% block content_title_text %}
+  {% trans "Confirm access" %}
+{% endblock content_title_text %}
+
+{% block content_body %}
+
+  {% block reauthenticate_content %}
+  {% endblock reauthenticate_content %}
+
+  {% if reauthentication_alternatives %}
+    <div class="ui small header">{% trans "Alternative options" %}</div>
+
+    <div class="ui list">
+      {% for alt in reauthentication_alternatives %}
+        <a href="{{ alt.url }}" class="item">{{ alt.description }}</a>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/account/password_change.html
+++ b/readthedocsext/theme/templates/account/password_change.html
@@ -1,19 +1,25 @@
 {% extends "profiles/base_edit.html" %}
 
-{% load i18n %}
-{% load crispy_forms_tags %}
+{% load trans from i18n %}
+{% load crispy from crispy_forms_tags %}
 
-{% block title %}{% trans "Security" %}{% endblock %}
-{% block profile_admin_change_password %}active{% endblock %}
-{% block edit_content_header %}{% trans "Security" %}{% endblock %}
-{% block edit_content_subheader %}{% trans "Change password" %}{% endblock %}
+{% block title %}
+  {% trans "Security" %}
+{% endblock title %}
+{% block profile_admin_security %}
+  active
+{% endblock profile_admin_security %}
+{% block edit_content_header %}
+  {% trans "Security" %}
+{% endblock edit_content_header %}
+{% block edit_content_subheader %}
+  {% trans "Change password" %}
+{% endblock edit_content_subheader %}
 
 {% block edit_content %}
-  <form method="POST" action="." class="ui form">
+  <form method="post" action="." class="ui form">
     {% csrf_token %}
     {{ form|crispy }}
-    <button class="ui primary button" type="submit">
-      {% trans "Save" %}
-    </button>
+    <button class="ui primary button" type="submit">{% trans "Save" %}</button>
   </form>
-{% endblock %}
+{% endblock edit_content %}

--- a/readthedocsext/theme/templates/account/reauthenticate.html
+++ b/readthedocsext/theme/templates/account/reauthenticate.html
@@ -1,0 +1,20 @@
+{% extends "account/base_reauthenticate.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block reauthenticate_content %}
+  <p>
+    {% blocktrans trimmed %}
+      Enter your account password to confirm access.
+    {% endblocktrans %}
+  </p>
+
+  {% url 'account_reauthenticate' as action_url %}
+  <form class="ui form" method="post" action="{{ action_url }}">
+    {% csrf_token %}
+    {{ form|crispy }}
+    {{ redirect_field }}
+    <button class="ui primary button" type="submit">{% trans "Confirm" %}</button>
+  </form>
+{% endblock reauthenticate_content %}

--- a/readthedocsext/theme/templates/mfa/authenticate.html
+++ b/readthedocsext/theme/templates/mfa/authenticate.html
@@ -1,0 +1,33 @@
+{% extends "mfa/base_entrance.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block head_title %}
+  {% trans "Verify sign in" %}
+{% endblock head_title %}
+{% block content_title_text %}
+  {% trans "Verify sign in" %}
+{% endblock content_title_text %}
+
+{% block content_body %}
+  <p>
+    {% blocktrans trimmed %}
+      Enter a two-factor authentication code to verify this sign in.
+    {% endblocktrans %}
+  </p>
+
+  {% url 'mfa_authenticate' as action_url %}
+  <form class="ui form" method="post" action="{{ action_url }}">
+    {% csrf_token %}
+    {{ form|crispy }}
+    {{ redirect_field }}
+
+    <div class="ui stackable relaxed text menu">
+      <a class="item" href="{% url "account_login" %}">{% trans "Cancel" %}</a>
+      <div class="right menu">
+        <button class="ui primary button" type="submit">{% trans "Verify" %}</button>
+      </div>
+    </div>
+  </form>
+{% endblock content_body %}

--- a/readthedocsext/theme/templates/mfa/base_manage.html
+++ b/readthedocsext/theme/templates/mfa/base_manage.html
@@ -1,0 +1,25 @@
+{% extends "profiles/base_edit.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block head_title %}
+  {% trans "Two-factor authentication" %}
+{% endblock head_title %}
+{% block profile_admin_security %}
+  active
+{% endblock profile_admin_security %}
+{% block edit_content_header %}
+  {% trans "Security" %}
+{% endblock edit_content_header %}
+{% block edit_content_subheader %}
+  <div class="ui breadcrumb">
+    <a href="{% url "mfa_index" %}" class="section">
+      {% trans "Two-factor authentication" %}
+    </a>
+    <span class="divider">/</span>
+    {% block edit_content_subheader_section %}
+      <div class="active section">{% trans "Manage" %}</div>
+    {% endblock edit_content_subheader_section %}
+  </div>
+{% endblock edit_content_subheader %}

--- a/readthedocsext/theme/templates/mfa/index.html
+++ b/readthedocsext/theme/templates/mfa/index.html
@@ -1,0 +1,87 @@
+{% extends "mfa/base_manage.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block edit_content %}
+
+  {% block mfa_totp %}
+    {% if "totp" in MFA_SUPPORTED_TYPES %}
+      {% if not authenticators.totp %}
+
+        {# Placeholder section onboarding users to TOTP #}
+        <div class="ui placeholder segment">
+          <div class="ui icon header">
+            <i class="fad fa-key-skeleton-left-right icon"></i>
+            {% trans "Set up two-factor authentication" %}
+
+            <span class="sub header">
+              {% trans "Activate to use a two-factor authenticator app or browser extension to protect your account." %}
+            </span>
+          </div>
+          {% url 'mfa_activate_totp' as activate_url %}
+          <a class="ui primary button" href="{{ activate_url }}">
+            {% trans "Activate" %}
+          </a>
+        </div>
+
+      {% else %}
+
+        <div class="ui raised green segment">
+          <p>
+            <i class="fad fa-shield-keyhole green icon"></i>
+            {% blocktrans trimmed %}
+              Two-factor authentication using an authenticator app is enabled.
+            {% endblocktrans %}
+          </p>
+
+          <a class="ui button"
+             data-bind="click: $root.show_modal('mfa-deactivate')">
+            {% trans "Deactivate" %}
+          </a>
+          <div class="ui small modal" data-modal-id="mfa-deactivate">
+            <div class="header">{% trans "Deactivate two-factor authentication?" %}</div>
+            <div class="content">
+              {% blocktrans trimmed %}
+                Are you sure you want to deactivate two-factor authentication?
+              {% endblocktrans %}
+            </div>
+            <div class="actions">
+
+              <form method="post" action="{% url 'mfa_deactivate_totp' %}">
+                {% csrf_token %}
+                <input class="ui negative button"
+                       type="submit"
+                       value="{% trans "Deactivate" %}">
+              </form>
+            </div>
+          </div>
+
+        </div>
+
+      {% endif %}
+    {% endif %}
+  {% endblock mfa_totp %}
+
+  {% block mfa_webauthn %}
+    {# TODO if we end up supporting this in the future, this section will need ported #}
+  {% endblock mfa_webauthn %}
+
+  {% block mfa_recovery %}
+    {# Skip placeholder segment, only show this section if recovery codes were previously generated #}
+    {% if "recovery_codes" in MFA_SUPPORTED_TYPES and authenticators.recovery_codes %}
+      <h3 class="ui small header">{% trans "Recovery codes" %}</h3>
+
+      <p>
+        {% blocktrans trimmed %}
+          Recovery codes are one-time use codes that can be used as backup two-factor authentication codes.
+        {% endblocktrans %}
+      </p>
+
+      {% url 'mfa_view_recovery_codes' as view_url %}
+      <a href="{{ view_url }}" class="ui button">
+        {% trans "Manage recovery codes" %}
+      </a>
+    {% endif %}
+  {% endblock mfa_recovery %}
+{% endblock edit_content %}

--- a/readthedocsext/theme/templates/mfa/reauthenticate.html
+++ b/readthedocsext/theme/templates/mfa/reauthenticate.html
@@ -1,0 +1,20 @@
+{% extends "account/base_reauthenticate.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block reauthenticate_content %}
+  <p>
+    {% blocktrans trimmed %}
+      Enter a two-factor authentication code to confirm access.
+    {% endblocktrans %}
+  </p>
+
+  {% url 'mfa_reauthenticate' as action_url %}
+  <form class="ui form" method="post" action="{{ action_url }}">
+    {% csrf_token %}
+    {{ form|crispy }}
+    {{ redirect_field }}
+    <button class="ui primary button" type="submit">{% trans "Confirm" %}</button>
+  </form>
+{% endblock reauthenticate_content %}

--- a/readthedocsext/theme/templates/mfa/recovery_codes/index.html
+++ b/readthedocsext/theme/templates/mfa/recovery_codes/index.html
@@ -1,0 +1,78 @@
+{% extends "mfa/recovery_codes/base.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block head_title %}
+  {% trans "Recovery codes" %}
+{% endblock head_title %}
+{% block edit_content_subheader_section %}
+  <div class="active section">{% trans "Recovery codes" %}</div>
+{% endblock edit_content_subheader_section %}
+
+{% block edit_content %}
+
+  {% if unused_codes %}
+
+    <p class="ui info message">
+      <i class="fad fa-exclamation-triangle"></i>
+      {% blocktrans trimmed %}
+        Keep these codes stored in a secure place, such as a password manager.
+      {% endblocktrans %}
+    </p>
+
+    <div class="ui raised segment">
+      <div class="ui list">
+        {% for code in unused_codes %}
+          <div class="item">
+            <code>{{ code }}</code>
+          </div>
+        {% endfor %}
+      </div>
+
+      <input type="hidden"
+             id="mfa-recovery-codes"
+             value="{{ unused_codes|join:" " }}" />
+      <button class="ui button" data-clipboard-target="input#mfa-recovery-codes">
+        <i class="fa-solid fa-copy icon"></i>
+        {% trans "Copy codes" %}
+      </button>
+
+      {% url 'mfa_download_recovery_codes' as download_url %}
+      <a href="{{ download_url }}" class="ui button">{% trans "Download codes" %}</a>
+
+    </div>
+  {% endif %}
+
+  <div class="ui red segment">
+    <h3 class="ui small header">{% trans "Generate new codes" %}</h3>
+
+    <p>
+      {% blocktrans %}
+        You can generate new recovery codes if you lost or used all of your previous recovery codes.
+        This will invalidate and previously generated codes.
+      {% endblocktrans %}
+    </p>
+
+    <a class="ui button"
+       data-bind="click: $root.show_modal('mfa-generate-recovery-codes')">
+      <i class="fa-duotone fa-trash icon"></i>
+      {% trans "Generate new codes" %}
+    </a>
+    <div class="ui mini modal" data-modal-id="mfa-generate-recovery-codes">
+      <div class="header">{% trans "Generate new codes" %}</div>
+      <div class="content">
+        {% blocktrans trimmed %}
+          Are you sure you want to regenerate new recovery codes?
+        {% endblocktrans %}
+      </div>
+      <div class="actions">
+        <form method="post" action="{% url "mfa_generate_recovery_codes" %}">
+          {% csrf_token %}
+          <input class="ui negative button"
+                 type="submit"
+                 value="{% trans "Generate new codes" %}">
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock edit_content %}

--- a/readthedocsext/theme/templates/mfa/totp/activate_form.html
+++ b/readthedocsext/theme/templates/mfa/totp/activate_form.html
@@ -1,0 +1,46 @@
+{% extends "mfa/totp/base.html" %}
+
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
+
+{% block head_title %}
+  {% trans "Activate authenticator app" %}
+{% endblock head_title %}
+{% block edit_content_subheader_section %}
+  <div class="active section">{% trans "Activate authenticator app" %}</div>
+{% endblock edit_content_subheader_section %}
+
+{% block edit_content %}
+  <p>
+    {% blocktrans trimmed %}
+      To protect your account with two-factor authentication,
+      set up your authenticator using the QR code or authenticator secret below
+      and input the generated verification code.
+    {% endblocktrans %}
+  </p>
+
+  <div class="ui form">
+    <div class="ui basic center aligned segment">
+      <img src="{{ totp_svg_data_uri }}" alt="{{ form.secret }}" />
+    </div>
+
+    <div class="ui raised segment">
+      <div class="field">
+        <label>{% trans "Authenticator secret" %}</label>
+        <div class="ui fluid action input">
+          <input type="text" value="{{ form.secret }}" id="mfa-secret" readonly="true">
+          <button class="ui right icon button" data-clipboard-target="input#mfa-secret">
+            <i class="fa-solid fa-copy icon"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    {% url 'mfa_activate_totp' as action_url %}
+    <form method="post" action="{{ action_url }}">
+      {% csrf_token %}
+      {{ form|crispy }}
+      <button class="ui primary button" type="submit">{% trans "Activate" %}</button>
+    </form>
+  </div>
+{% endblock edit_content %}

--- a/readthedocsext/theme/templates/profiles/base_edit.html
+++ b/readthedocsext/theme/templates/profiles/base_edit.html
@@ -1,13 +1,11 @@
 {% extends "base.html" %}
 
-{% load i18n %}
-{% load core_tags %}
+{% load trans from i18n %}
 
 {% block notifications %}
   {# User notifications only #}
-  <readthedocs-notification-list
-    url="{% url "users-notifications-list" request.user.username %}"
-    csrf-token="{{ csrf_token }}">
+  <readthedocs-notification-list url="{% url "users-notifications-list" request.user.username %}"
+                                 csrf-token="{{ csrf_token }}">
   </readthedocs-notification-list>
 
   {{ block.super }}
@@ -18,17 +16,27 @@
     <div class="five wide computer five wide tablet sixteen wide mobile column">
       <div class="ui vertical pointing fluid menu">
         {% block profile-admin-nav %}
-          <a class="item {% block profile_admin_details %}{% endblock %}" href="{% url 'profiles_profile_edit' %}">{% trans "Account" %}</a>
-          <a class="item {% block profile_admin_change_email %}{% endblock %}" href="{% url 'account_email' %}">{% trans "Email addresses" %}</a>
-          <a class="item {% block profile_admin_change_password %}{% endblock %}" href="{% url 'account_change_password' %}">{% trans "Security" %}</a>
-          <a class="item {% block profile_admin_social_accounts %}{% endblock %}" href="{% url 'socialaccount_connections' %}">{% trans "Connected services" %}</a>
-          <a class="item {% block profile-admin-security-log %}{% endblock %}" href="{% url 'profiles_security_log' %}">{% trans "Security log" %}</a>
-          <a class="item {% block profile_admin_tokens %}{% endblock %}" href="{% url 'profiles_tokens' %}">{% trans "API tokens" %}</a>
+          {# djlint: off T003 #}
+          <a class="item {% block profile_admin_details %}{% endblock %}"
+             href="{% url 'profiles_profile_edit' %}">{% trans "Account" %}</a>
+          <a class="item {% block profile_admin_change_email %}{% endblock %}"
+             href="{% url 'account_email' %}">{% trans "Email addresses" %}</a>
+          <a class="item {% block profile_admin_security %}{% endblock %}"
+             href="{% url 'account_change_password' %}">{% trans "Security" %}</a>
+          <a class="item {% block profile_admin_social_accounts %}{% endblock %}"
+             href="{% url 'socialaccount_connections' %}">{% trans "Connected services" %}</a>
+          <a class="item {% block profile-admin-security-log %}{% endblock %}"
+             href="{% url 'profiles_security_log' %}">{% trans "Security log" %}</a>
+          <a class="item {% block profile_admin_tokens %}{% endblock %}"
+             href="{% url 'profiles_tokens' %}">{% trans "API tokens" %}</a>
 
           {% if USE_PROMOS %}
-            <a class="item {% block profile_admin_gold_edit %}{% endblock %}" href="{% url 'gold_detail' %}">{% trans "Gold membership" %}</a>
-            <a class="item {% block profile_admin_advertising %}{% endblock %}" href="{% url 'account_advertising' %}">{% trans "Advertising" %}</a>
+            <a class="item {% block profile_admin_gold_edit %}{% endblock %}"
+               href="{% url 'gold_detail' %}">{% trans "Gold membership" %}</a>
+            <a class="item {% block profile_admin_advertising %}{% endblock %}"
+               href="{% url 'account_advertising' %}">{% trans "Advertising" %}</a>
           {% endif %}
+          {# djlint: on T003 #}
         {% endblock %}
       </div>
 
@@ -37,8 +45,7 @@
         <div class="ui basic segment">
           <h2 class="ui small header">{% trans "Help topics" %}</h2>
           {% block edit_sidebar_help_topics %}
-            <div data-embed-doc-view="{% block edit_sidebar_embed_doc %}{% endblock %}"
-                 data-bind="template: { name: 'doc-topics' }">
+            <div data-embed-doc-view="{% block edit_sidebar_embed_doc %}{% endblock %}" data-bind="template: { name: 'doc-topics' }">
             </div>
           {% endblock edit_sidebar_help_topics %}
         </div>


### PR DESCRIPTION
I placed this as a subpage under the profile "Security" admin dashboard
for now, though this is still not linked anywhere.

The entrance pages use the minimal login base templates, while the
management pages use the user profile edit base as a base template, so
that all of the management functions appear under the user profile
admin.

- Fixes #443

[Screencast from 2024-09-11 14-07-31.webm](https://github.com/user-attachments/assets/efae06c4-c14f-448f-a496-7f39fbe370dd)
