### PR TITLE
Update password auth view

### DIFF
--- a/readthedocsext/theme/templates/acl/shared_password_required.html
+++ b/readthedocsext/theme/templates/acl/shared_password_required.html
@@ -1,30 +1,39 @@
-{% extends "proxito/base.html" %}
+{# Follow same pattern as Allauth here #}
+{% extends "account/base_entrance.html" %}
+
 {% load trans blocktrans from i18n %}
 {% load crispy from crispy_forms_tags %}
 
 {% block title %}
   {% trans "Authentication required" %}
 {% endblock title %}
+{% block content_title_text %}
+  {% trans "Authentication required" %}
+{% endblock content_title_text %}
 
-{% block content %}
-  <h1>{% trans "Authentication required" %}</h1>
-
+{% block content_body %}
   <p>
-    {% blocktrans with project_name=project.name %}
-    You need special requirements to access "{{ project_name }}" project documentation.
-    Please, provide a valid password to see the docs.
+    {% blocktrans trimmed %}
+      You must be authenticated in order to access this site,
+      please provide a password to continue.
     {% endblocktrans %}
   </p>
 
   <form class="ui form" method="post">
     {% csrf_token %}
     {{ form|crispy }}
-    <button class="ui primary button" type="submit">{% trans "Log in" %}</button>
-  </form>
 
-  <p>
-    {% blocktrans trimmed with domain=PRODUCTION_DOMAIN %}
-      Already have an account? Then please <a href="https://{{ domain }}/accounts/login/">log in</a>.
-    {% endblocktrans %}
-  </p>
-{% endblock content %}
+    <div class="ui stackable relaxed text menu">
+      {% comment %}
+        Using the `next` query param here is hopefully safe. It restarts the
+        login workflow, where just linking to the login form or production
+        domain both do not. Both of these link to a slightly different form.
+      {% endcomment %}
+      <a class="item" href="{{ request.GET.next }}">{% trans "Try using another method" %}</a>
+      <div class="right menu">
+        <button class="ui primary button" type="submit">{% trans "Log in" %}</button>
+      </div>
+    </div>
+
+  </form>
+{% endblock content_body %}


### PR DESCRIPTION
Uses same base as Allauth views, which is a derivate of the Proxito base
view already. This fixes some copy and elements, and addresses the link
to log in with other methods at least temporarily.

- Fixes #393

![image](https://github.com/user-attachments/assets/18adf6db-7682-4348-8112-da3a3acffda1)
