### PR TITLE
Fix exception with missing pagination tag

### DIFF
--- a/readthedocsext/theme/templates/includes/crud/table_list.html
+++ b/readthedocsext/theme/templates/includes/crud/table_list.html
@@ -65,7 +65,7 @@
 {% endcomment %}
 
 {% load trans blocktrans from i18n %}
-{% load autopaginate from pagination_tags %}
+{% load autopaginate paginate from pagination_tags %}
 
 <div {% block view_binding %}{% endblock view_binding %}>
   {% block top_menu %}


### PR DESCRIPTION
From #486, linting introduced a missing template tag