### PR TITLE
Fix dynamic import path

### DIFF
--- a/readthedocsext/theme/templatetags/ext_theme_tags.py
+++ b/readthedocsext/theme/templatetags/ext_theme_tags.py
@@ -69,7 +69,7 @@ def settings_dashboard():
 
     return {
         "debug": getattr(settings, "DEBUG", False),
-        "webpack_public_path": f"{{ public_path_prefix }}/readthedocsext/theme/",
+        "webpack_public_path": f"{public_path_prefix}/readthedocsext/theme/",
         "production_domain": settings.PRODUCTION_DOMAIN,
         "sentry": getattr(settings, "SENTRY_BROWSER", {}),
     }


### PR DESCRIPTION
Django tags apparently don't work in format strings 🙃