### PR TITLE
Be more defensive in our language code display

### DIFF
--- a/readthedocsext/theme/templatetags/ext_theme_tags.py
+++ b/readthedocsext/theme/templatetags/ext_theme_tags.py
@@ -139,20 +139,32 @@ def get_spam_score(project):
 # We need to decide what to do at the DB level still, but at least this approach solves the immediate issue.
 @register.filter
 def readthedocs_language_name(lang_code):
-    if lang_code == "zh":
-        return language_name("zh-cn")
-    return language_name(lang_code)
+    try:
+        if lang_code == "zh":
+            return language_name("zh-cn")
+        return language_name(lang_code)
+    except Exception:
+        log.exception("Error getting language name")
+        return "Unknown"
 
 
 @register.filter
 def readthedocs_language_name_translated(lang_code):
-    if lang_code == "zh":
-        return language_name_translated("zh-cn")
-    return language_name_translated(lang_code)
+    try:
+        if lang_code == "zh":
+            return language_name_translated("zh-cn")
+        return language_name_translated(lang_code)
+    except Exception:
+        log.exception("Error getting language name")
+        return "Unknown"
 
 
 @register.filter
 def readthedocs_language_name_local(lang_code):
-    if lang_code == "zh":
-        return language_name_local("zh-cn")
-    return language_name_local(lang_code)
+    try:
+        if lang_code == "zh":
+            return language_name_local("zh-cn")
+        return language_name_local(lang_code)
+    except Exception:
+        log.exception("Error getting language name")
+        return "Unknown"


### PR DESCRIPTION
This is causing 500s on the dashboard,
so just logging it in Sentry for now instead of 500ing.

Refs https://read-the-docs.sentry.io/issues/5642802576/?project=148442&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0