### PR TITLE
Addons: split single checkbox into two

### DIFF
--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -76,8 +76,10 @@
 
       {% block addons_notifications %}
         <div class="ui tab" data-tab="notifications">
-          {{ form.external_version_warning_enabled | as_crispy_field }}
-          {{ form.stable_latest_version_warning_enabled | as_crispy_field }}
+          {{ form.notifications_enabled | as_crispy_field }}
+          {{ form.notifications_show_on_external | as_crispy_field }}
+          {{ form.notifications_show_on_latest | as_crispy_field }}
+          {{ form.notifications_show_on_non_stable | as_crispy_field }}
         </div>
       {% endblock addons_notifications %}
 


### PR DESCRIPTION
Instead of showing one checkbox to enable "Show notification on latest and non-stable versions" we have two checkboxes now:

- "Show notification on latest version"
- "Show notification on non-stable versions"


![Screenshot_2024-10-29_15-52-36](https://github.com/user-attachments/assets/60a35c09-cf9d-4429-af53-41515f00ecac)

Requires https://github.com/readthedocs/addons/pull/414
Requires https://github.com/readthedocs/readthedocs.org/pull/11718