### PR TITLE
Rename context_text to content_text

### DIFF
--- a/readthedocsext/theme/templates/account/email.html
+++ b/readthedocsext/theme/templates/account/email.html
@@ -6,7 +6,9 @@
 {% block title %}
   {% trans "Email addresses" %}
 {% endblock title %}
-{% block profile_admin_change_email %}active{% endblock profile_admin_change_email %}
+{% block profile_admin_change_email %}
+  active
+{% endblock profile_admin_change_email %}
 {% block edit_content_header %}
   {% trans "Email addresses" %}
 {% endblock edit_content_header %}

--- a/readthedocsext/theme/templates/account/email.html
+++ b/readthedocsext/theme/templates/account/email.html
@@ -1,6 +1,6 @@
 {% extends "profiles/base_edit.html" %}
 
-{% load i18n %}
+{% load trans blocktrans from i18n %}
 {% load crispy_forms_tags %}
 
 {% block title %}{% trans "Email addresses" %}{% endblock %}

--- a/readthedocsext/theme/templates/account/email.html
+++ b/readthedocsext/theme/templates/account/email.html
@@ -3,20 +3,24 @@
 {% load trans blocktrans from i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{% trans "Email addresses" %}{% endblock %}
+{% block title %}
+  {% trans "Email addresses" %}
+{% endblock %}
 {% block profile_admin_change_email %}active{% endblock %}
-{% block edit_content_header %} {% trans "Email addresses" %} {% endblock %}
+{% block edit_content_header %}
+  {% trans "Email addresses" %}
+{% endblock %}
 
 {% block edit_content %}
   {% include "account/partials/email_list.html" with objects=user.emailaddress_set.all %}
 
-  <h3 class="ui medium header">
-    {% trans "Add email address" %}
-  </h3>
+  <h3 class="ui medium header">{% trans "Add email address" %}</h3>
 
   <form class="ui form" method="post" action="{% url 'account_email' %}">
     {% csrf_token %}
     {{ form|crispy }}
-    <button class="ui primary button" type="submit" name="action_add">{% trans "Add email" %}</button>
+    <button class="ui primary button" type="submit" name="action_add">
+      {% trans "Add email" %}
+    </button>
   </form>
 {% endblock %}

--- a/readthedocsext/theme/templates/account/email.html
+++ b/readthedocsext/theme/templates/account/email.html
@@ -5,11 +5,11 @@
 
 {% block title %}
   {% trans "Email addresses" %}
-{% endblock %}
-{% block profile_admin_change_email %}active{% endblock %}
+{% endblock title %}
+{% block profile_admin_change_email %}active{% endblock profile_admin_change_email %}
 {% block edit_content_header %}
   {% trans "Email addresses" %}
-{% endblock %}
+{% endblock edit_content_header %}
 
 {% block edit_content %}
   {% include "account/partials/email_list.html" with objects=user.emailaddress_set.all %}
@@ -23,4 +23,4 @@
       {% trans "Add email" %}
     </button>
   </form>
-{% endblock %}
+{% endblock edit_content %}

--- a/readthedocsext/theme/templates/account/email.html
+++ b/readthedocsext/theme/templates/account/email.html
@@ -1,7 +1,7 @@
 {% extends "profiles/base_edit.html" %}
 
 {% load trans blocktrans from i18n %}
-{% load crispy_forms_tags %}
+{% load crispy from crispy_forms_tags %}
 
 {% block title %}
   {% trans "Email addresses" %}

--- a/readthedocsext/theme/templates/account/partials/email_list.html
+++ b/readthedocsext/theme/templates/account/partials/email_list.html
@@ -11,8 +11,7 @@
 {% block top_menu %}
 {% endblock top_menu %}
 
-{% block create_button %}
-{% endblock %}
+{% block create_button %}{% endblock %}
 
 {% block list_placeholder_icon_class %}fa-duotone fa-envelope-dot{% endblock %}
 {% block list_placeholder_header %}
@@ -35,7 +34,10 @@
         <i class="fa-solid fa-star icon"></i>
         <form action="{{ form_url }}" method="post">
           {% csrf_token %}
-          <input type="hidden" name="email" {% if object.primary %}checked="checked"{% endif %} value="{{ object.email }}"/>
+          <input type="hidden"
+                 name="email"
+                 {% if object.primary %}checked="checked"{% endif %}
+                 value="{{ object.email }}" />
           <input type="hidden" name="action_primary" value="" />
         </form>
       </div>
@@ -45,7 +47,10 @@
         <i class="fa-solid fa-refresh icon"></i>
         <form action="{{ form_url }}" method="post">
           {% csrf_token %}
-          <input type="hidden" name="email" {% if object.primary %}checked="checked"{% endif %} value="{{ object.email }}"/>
+          <input type="hidden"
+                 name="email"
+                 {% if object.primary %}checked="checked"{% endif %}
+                 value="{{ object.email }}" />
           <input type="hidden" name="action_send" value="" />
         </form>
       </div>
@@ -64,9 +69,7 @@
 {% block list_item_header %}
   <div>
     {{ object.email }}
-    {% if object.primary %}
-      <i class="fa-solid fa-star icon"></i>
-    {% endif %}
+    {% if object.primary %}<i class="fa-solid fa-star icon"></i>{% endif %}
   </div>
   <div class="sub header">
     <div class="ui horizontal list">
@@ -82,9 +85,7 @@
         </span>
       {% endif %}
       {% if object.primary %}
-        <span class="item">
-          {% trans "Primary email" %}
-        </span>
+        <span class="item">{% trans "Primary email" %}</span>
       {% endif %}
     </div>
   </div>

--- a/readthedocsext/theme/templates/account/partials/email_list.html
+++ b/readthedocsext/theme/templates/account/partials/email_list.html
@@ -5,9 +5,12 @@
 {% block top_menu %}
 {% endblock top_menu %}
 
-{% block create_button %}{% endblock create_button %}
+{% block create_button %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-envelope-dot{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-envelope-dot
+{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No email addresses have been configured yet

--- a/readthedocsext/theme/templates/account/partials/email_list.html
+++ b/readthedocsext/theme/templates/account/partials/email_list.html
@@ -5,9 +5,9 @@
 {% block top_menu %}
 {% endblock top_menu %}
 
-{% block create_button %}{% endblock %}
+{% block create_button %}{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fa-duotone fa-envelope-dot{% endblock %}
+{% block list_placeholder_icon_class %}fa-duotone fa-envelope-dot{% endblock list_placeholder_icon_class %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     No email addresses have been configured yet

--- a/readthedocsext/theme/templates/account/partials/email_list.html
+++ b/readthedocsext/theme/templates/account/partials/email_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_menu %}
 {% endblock top_menu %}

--- a/readthedocsext/theme/templates/account/partials/email_list.html
+++ b/readthedocsext/theme/templates/account/partials/email_list.html
@@ -54,7 +54,7 @@
     {% blocktrans trimmed asvar content_text with email=object.email %}
       Remove email address {{ email }}?
     {% endblocktrans %}
-    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_name="action_remove" action_text=action_text context_text=context_text field_name="email" field_value=object.email %}
+    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_name="action_remove" action_text=action_text content_text=content_text field_name="email" field_value=object.email %}
   </div>
 {% endblock list_item_right_menu %}
 

--- a/readthedocsext/theme/templates/gold/partials/projects_list.html
+++ b/readthedocsext/theme/templates/gold/partials/projects_list.html
@@ -34,9 +34,7 @@
 {% endblock list_item_image %}
 
 {% block list_item_header %}
-  <a href="{{ object.get_absolute_url }}">
-    {{ object }}
-  </a>
+  <a href="{{ object.get_absolute_url }}">{{ object }}</a>
 {% endblock list_item_header %}
 
 {% block list_item_extra %}

--- a/readthedocsext/theme/templates/gold/partials/projects_list.html
+++ b/readthedocsext/theme/templates/gold/partials/projects_list.html
@@ -1,6 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
+{% load trans blocktrans from i18n %}
 
 {% block top_menu %}
 {% endblock top_menu %}

--- a/readthedocsext/theme/templates/gold/partials/projects_list.html
+++ b/readthedocsext/theme/templates/gold/partials/projects_list.html
@@ -5,8 +5,11 @@
 {% block top_menu %}
 {% endblock top_menu %}
 
-{% block list_placeholder_class %}ui short placeholder segment{% endblock list_placeholder_icon_class %}
-{% block list_placeholder_icon %}{% endblock list_placeholder_icon %}
+{% block list_placeholder_class %}
+  ui short placeholder segment
+{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_icon %}
+{% endblock list_placeholder_icon %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     Ad-free projects

--- a/readthedocsext/theme/templates/gold/partials/projects_list.html
+++ b/readthedocsext/theme/templates/gold/partials/projects_list.html
@@ -5,8 +5,8 @@
 {% block top_menu %}
 {% endblock top_menu %}
 
-{% block list_placeholder_class %}ui short placeholder segment{% endblock %}
-{% block list_placeholder_icon %}{% endblock %}
+{% block list_placeholder_class %}ui short placeholder segment{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_icon %}{% endblock list_placeholder_icon %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     Ad-free projects

--- a/readthedocsext/theme/templates/gold/partials/projects_list.html
+++ b/readthedocsext/theme/templates/gold/partials/projects_list.html
@@ -27,7 +27,7 @@
   {% blocktrans trimmed asvar content_text with name=object.name %}
     Remove ad-free status for project {{ name }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}

--- a/readthedocsext/theme/templates/organizations/partials/owners_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/owners_list.html
@@ -50,7 +50,7 @@
     {% blocktrans trimmed asvar content_text with username=object.owner.username organization=organization.name %}
       Remove user {{ username }} as an owner of the {{ organization }} organization?
     {% endblocktrans %}
-    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text is_disabled=is_last_user %}
+    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text is_disabled=is_last_user %}
   {% endif %}
 {% endblock list_item_right_buttons %}
 

--- a/readthedocsext/theme/templates/organizations/partials/owners_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/owners_list.html
@@ -34,9 +34,9 @@
       </div>
     </div>
   {% endif %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fad fa-user-plus icon{% endblock %}
+{% block list_placeholder_icon_class %}fad fa-user-plus icon{% endblock list_placeholder_icon_class %}
 {# This placeholder content should never be visible, there should always be one owner #}
 {% block list_placeholder_header %}
   {% trans "This organization has no owner users" %}
@@ -55,6 +55,7 @@
 
 {% block list_item_image %}
   <img class="ui rounded square image"
+       alt={% trans "User avatar" %}
        src="{% gravatar_url object.owner.email 64 %}">
 {% endblock list_item_image %}
 
@@ -78,4 +79,4 @@
 {% block list_item_meta_items %}
 {% endblock list_item_meta_items %}
 
-{% block list_item_extra %}{% endblock %}
+{% block list_item_extra %}{% endblock list_item_extra %}

--- a/readthedocsext/theme/templates/organizations/partials/owners_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/owners_list.html
@@ -36,7 +36,9 @@
   {% endif %}
 {% endblock create_button %}
 
-{% block list_placeholder_icon_class %}fad fa-user-plus icon{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_icon_class %}
+  fad fa-user-plus icon
+{% endblock list_placeholder_icon_class %}
 {# This placeholder content should never be visible, there should always be one owner #}
 {% block list_placeholder_header %}
   {% trans "This organization has no owner users" %}
@@ -55,7 +57,7 @@
 
 {% block list_item_image %}
   <img class="ui rounded square image"
-       alt={% trans "User avatar" %}
+       alt="{% trans "User avatar" %}"
        src="{% gravatar_url object.owner.email 64 %}">
 {% endblock list_item_image %}
 
@@ -79,4 +81,5 @@
 {% block list_item_meta_items %}
 {% endblock list_item_meta_items %}
 
-{% block list_item_extra %}{% endblock list_item_extra %}
+{% block list_item_extra %}
+{% endblock list_item_extra %}

--- a/readthedocsext/theme/templates/organizations/partials/owners_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/owners_list.html
@@ -23,11 +23,11 @@
     </a>
 
     <div class="ui mini modal" data-modal-id="invite-owner">
-      <div class="header">
-        {% trans "Invite organization owner" %}
-      </div>
+      <div class="header">{% trans "Invite organization owner" %}</div>
       <div class="content">
-        <form class="ui form" method="post" action="{% url "organization_owner_add" organization.slug %}">
+        <form class="ui form"
+              method="post"
+              action="{% url "organization_owner_add" organization.slug %}">
           {% csrf_token %}
           {{ form|crispy }}
           <input class="ui button" type="submit" value="{% trans "Invite owner" %}">
@@ -55,7 +55,8 @@
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}
-  <img class="ui rounded square image" src="{% gravatar_url object.owner.email 64 %}">
+  <img class="ui rounded square image"
+       src="{% gravatar_url object.owner.email 64 %}">
 {% endblock list_item_image %}
 
 {% block list_item_header %}
@@ -70,9 +71,7 @@
 
     </a>
     {% if full_name %}
-      <div class="sub header">
-        {{ object.owner.username }}
-      </div>
+      <div class="sub header">{{ object.owner.username }}</div>
     {% endif %}
   {% endwith %}
 {% endblock list_item_header %}
@@ -80,5 +79,4 @@
 {% block list_item_meta_items %}
 {% endblock list_item_meta_items %}
 
-{% block list_item_extra %}
-{% endblock %}
+{% block list_item_extra %}{% endblock %}

--- a/readthedocsext/theme/templates/organizations/partials/owners_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/owners_list.html
@@ -5,11 +5,10 @@
   update the templates for project maintainers and team member lists
 {% endcomment %}
 
-{% load i18n %}
-{% load gravatar %}
-{% load humanize %}
-{% load privacy_tags %}
-{% load crispy_forms_tags %}
+{% load trans blocktrans from i18n %}
+{% load gravatar_url from gravatar %}
+{% load is_admin from privacy_tags %}
+{% load crispy from crispy_forms_tags %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
@@ -79,7 +79,7 @@
   {% blocktrans trimmed asvar content_text with rule=object.get_description %}
     Remove rule {{ rule }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}

--- a/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
@@ -52,7 +52,7 @@
   {% blocktrans trimmed asvar content_text with name=object.name %}
     Remove variable {{ name }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -1,10 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -49,7 +49,7 @@
   {% blocktrans trimmed asvar content_text with description=object.get_integration_type_display %}
     Remove integration {{ description }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}

--- a/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
@@ -45,7 +45,7 @@
   {% blocktrans trimmed asvar content_text with email=object.email %}
     Remove email notification to {{ email }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text field_name="email" field_value=object.email %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text field_name="email" field_value=object.email %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -24,7 +24,9 @@
   {% blocktrans trimmed %}
     No redirects exist yet
   {% endblocktrans %}
-  <div class="sub header">{% trans "Redirects allow you to fix links to pages that have moved." %}</div>
+  <div class="sub header">
+    {% trans "Redirects allow you to fix links to pages that have moved." %}
+  </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -75,7 +75,7 @@
   {% blocktrans trimmed asvar content_text with redirect=object %}
     Remove redirect {{ redirect }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
@@ -50,7 +50,7 @@
   {% blocktrans trimmed asvar content_text with name=object.child.name %}
     Remove subproject {{ name }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}

--- a/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
@@ -1,10 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
@@ -51,7 +51,7 @@
   {% blocktrans trimmed asvar content_text with share=object.description %}
     Remove share {{ share }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}

--- a/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
@@ -52,7 +52,7 @@
     Remove project {{ language }} translation for
     project {{ name }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}

--- a/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
@@ -1,12 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/user_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/user_list.html
@@ -13,7 +13,8 @@
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
 {% endblock create_button %}
 
-{% block list_placeholder_icon %}{% endblock list_placeholder_icon %}
+{% block list_placeholder_icon %}
+{% endblock list_placeholder_icon %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     This project currently has no maintainers.
@@ -38,7 +39,7 @@
 
 {% block list_item_image %}
   <img class="ui rounded square image"
-       alt={% trans "User avatar" %}
+       alt="{% trans "User avatar" %}"
        src="{% gravatar_url object.email 64 %}">
 {% endblock list_item_image %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/user_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/user_list.html
@@ -11,9 +11,9 @@
   {% url "projects_users_create" project.slug as create_url %}
   {% trans "Add maintainer" as create_text %}
   {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
-{% endblock %}
+{% endblock create_button %}
 
-{% block list_placeholder_icon %}{% endblock %}
+{% block list_placeholder_icon %}{% endblock list_placeholder_icon %}
 {% block list_placeholder_header %}
   {% blocktrans trimmed %}
     This project currently has no maintainers.
@@ -38,6 +38,7 @@
 
 {% block list_item_image %}
   <img class="ui rounded square image"
+       alt={% trans "User avatar" %}
        src="{% gravatar_url object.email 64 %}">
 {% endblock list_item_image %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/user_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/user_list.html
@@ -34,9 +34,9 @@
   {% endblocktrans %}
   {# Repeating the include because Django templates make conditional variables impossible #}
   {% if object == request.user %}
-    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url field_name="username" field_value=object.username action_text=action_text context_text=context_text is_disabled=True %}
+    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url field_name="username" field_value=object.username action_text=action_text content_text=content_text is_disabled=True %}
   {% else %}
-    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url field_name="username" field_value=object.username action_text=action_text context_text=context_text is_disabled=False %}
+    {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url field_name="username" field_value=object.username action_text=action_text content_text=content_text is_disabled=False %}
   {% endif %}
 {% endblock list_item_right_buttons %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/user_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/user_list.html
@@ -41,7 +41,8 @@
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}
-  <img class="ui rounded square image" src="{% gravatar_url object.email 64 %}">
+  <img class="ui rounded square image"
+       src="{% gravatar_url object.email 64 %}">
 {% endblock list_item_image %}
 
 {% block list_item_header %}
@@ -56,9 +57,7 @@
 
     </a>
     {% if full_name %}
-      <div class="sub header">
-        {{ object.username }}
-      </div>
+      <div class="sub header">{{ object.username }}</div>
     {% endif %}
   {% endwith %}
 {% endblock list_item_header %}

--- a/readthedocsext/theme/templates/projects/partials/edit/user_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/user_list.html
@@ -1,12 +1,8 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
+{% load trans blocktrans from i18n %}
 
-{% load gravatar %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load gravatar_url from gravatar %}
 
 {% block top_left_menu_items %}
 {% endblock top_left_menu_items %}

--- a/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
@@ -44,7 +44,7 @@
   {% blocktrans trimmed asvar content_text with url=object.url %}
     Remove webhook to {{ url }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text context_text=context_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}

--- a/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
@@ -1,10 +1,6 @@
 {% extends "includes/crud/table_list.html" %}
 
-{% load i18n %}
-
-{% load core_tags %}
-{% load privacy_tags %}
-{% load projects_tags %}
+{% load trans blocktrans from i18n %}
 
 {% block create_button %}
   {% url "projects_webhooks_create" project.slug as create_url %}


### PR DESCRIPTION
The remove_button partial expects a variable named `content_text`, but we were passing `context_text` instead. It was working before because all variables from the current template are passed to the partial.