### PR TITLE
Add project: modal with instructions about adding a config file

### DIFF
--- a/readthedocsext/theme/templates/projects/import_base.html
+++ b/readthedocsext/theme/templates/projects/import_base.html
@@ -108,9 +108,7 @@
                         </p>
                       </div>
                       <div class="actions">
-                        <form method="post" action="{{ form_url }}">
-                          <div class="ui cancel button">{% trans "Close" %}</div>
-                        </form>
+                        <div class="ui cancel button">{% trans "Close" %}</div>
                       </div>
                     </div>
 

--- a/readthedocsext/theme/templates/projects/import_base.html
+++ b/readthedocsext/theme/templates/projects/import_base.html
@@ -92,19 +92,20 @@
 
                   {% if wizard.steps.current == "config" %}
                     <div class="ui small modal" data-modal-id="i-need-help">
-                      <div class="header">Add configuration file to your project</div>
+                      <div class="header">{% trans "Add configuration file to your project" %}</div>
                       <div class="content">
-                        <p>These are the steps you need to follow:</p>
+                        <p>{% trans "These are the steps you need to follow:" %}</p>
                         <ol>
                           <li>
-                            Create a <code>.readthedocs.yaml</code> in your project.
+                            {% trans "Create a <code>.readthedocs.yaml</code> file in your repository." %}
                           </li>
-                          <li>Copy and paste the content of the example.</li>
-                          <li>Open a pull request with these changes.</li>
-                          <li>Merge the pull request in your project.</li>
+                          <li>
+                            {% trans "Copy the contents of one of our examples to your project's <code>.readthedocs.yaml</code>." %}
+                          </li>
+                          <li>{% trans "Merge this change to your project's repository." %}.</li>
                         </ol>
                         <p>
-                          Once that's done Read the Docs will be able to build the documentation for your project.
+                          {% trans "Once that's done Read the Docs will be able to build your project's documentation." %}
                         </p>
                       </div>
                       <div class="actions">

--- a/readthedocsext/theme/templates/projects/import_base.html
+++ b/readthedocsext/theme/templates/projects/import_base.html
@@ -1,7 +1,7 @@
 {% extends "projects/base.html" %}
 
-{% load i18n %}
-{% load crispy_forms_tags %}
+{% load blocktrans trans from i18n %}
+{% load crispy from crispy_forms_tags %}
 
 {% block title %}
   {% trans "Add project" %}
@@ -81,12 +81,45 @@
                   {% if wizard.steps.prev %}
                     <button class="ui button"
                             name="wizard_goto_step"
-                            value="{{ wizard.steps.prev }}">{% trans "Previous" %}</button>
+                            value="{{ wizard.steps.prev }}">
+                      {% trans "Previous" %}
+                    </button>
                   {% endif %}
 
                   {% if wizard.steps.next %}
                     <input class="ui button primary" type="submit" value="{% trans "Next" %}" />
-                  {% else %}
+                  {% endif %}
+
+                  {% if wizard.steps.current == "config" %}
+                    <div class="ui small modal" data-modal-id="i-need-help">
+                      <div class="header">Add configuration file to your project</div>
+                      <div class="content">
+                        <p>These are the steps you need to follow:</p>
+                        <ol>
+                          <li>
+                            Create a <code>.readthedocs.yaml</code> in your project.
+                          </li>
+                          <li>Copy and paste the content of the example.</li>
+                          <li>Open a pull request with these changes.</li>
+                          <li>Merge the pull request in your project.</li>
+                        </ol>
+                        <p>
+                          Once that's done Read the Docs will be able to build the documentation for your project.
+                        </p>
+                      </div>
+                      <div class="actions">
+                        <form method="post" action="{{ form_url }}">
+                          <div class="ui cancel button">{% trans "Close" %}</div>
+                        </form>
+                      </div>
+                    </div>
+
+                    <button data-bind="click: $root.show_modal('i-need-help')"
+                            data-contet="{% trans "I need help" %}"
+                            class="ui button">
+                      {% trans "I need help" %}
+                    </button>
+
                     <input class="ui button primary"
                            type="submit"
                            value="{% trans "This file exists" %}" />


### PR DESCRIPTION
This adds a button "I need help" that shows a modal with more instructions about how to add the required `.readthedocs.yaml`.

I will need some help with the copy/instructions we want to show the customer.

![Screenshot_2024-11-05_15-52-03](https://github.com/user-attachments/assets/85b2c125-a2bd-4704-bfd6-b94ffba8d976)

Closes https://github.com/readthedocs/ext-theme/issues/445