### PR TITLE
Add 403 CSRF template

### DIFF
--- a/readthedocsext/theme/templates/403_csrf.html
+++ b/readthedocsext/theme/templates/403_csrf.html
@@ -1,0 +1,1 @@
+errors/dashboard/403_csrf.html

--- a/readthedocsext/theme/templates/errors/dashboard/403_csrf.html
+++ b/readthedocsext/theme/templates/errors/dashboard/403_csrf.html
@@ -1,33 +1,6 @@
-{% extends "errors/dashboard/base.html" %}
+{% extends "errors/dashboard/403.html" %}
 
 {% load blocktrans trans from i18n %}
-
-{% block title %}
-  {% trans "Access restricted" %}
-{% endblock title %}
-
-{% block error_status %}
-  403
-{% endblock error_status %}
-{% block error_title %}
-  {{ block.super }}
-  {% trans "Access restricted" %}
-{% endblock error_title %}
-{% block error_subtitle_text %}
-{% endblock error_subtitle_text %}
-
-{% block error_icon_computer_name %}
-  fa-lock-keyhole
-{% endblock error_icon_computer_name %}
-{% block error_icon_mobile_name %}
-  fa-lock-keyhole
-{% endblock error_icon_mobile_name %}
-{% block error_icon_computer_style %}
-  --fa-primary-color: orange;
-{% endblock error_icon_computer_style %}
-{% block error_icon_mobile_style %}
-  --fa-primary-color: orange;
-{% endblock error_icon_mobile_style %}
 
 {% block error_content %}
   <p>

--- a/readthedocsext/theme/templates/errors/dashboard/403_csrf.html
+++ b/readthedocsext/theme/templates/errors/dashboard/403_csrf.html
@@ -1,0 +1,48 @@
+{% extends "errors/dashboard/base.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block title %}
+  {% trans "Access restricted" %}
+{% endblock title %}
+
+{% block error_status %}
+  403
+{% endblock error_status %}
+{% block error_title %}
+  {{ block.super }}
+  {% trans "Access restricted" %}
+{% endblock error_title %}
+{% block error_subtitle_text %}
+{% endblock error_subtitle_text %}
+
+{% block error_icon_computer_name %}
+  fa-lock-keyhole
+{% endblock error_icon_computer_name %}
+{% block error_icon_mobile_name %}
+  fa-lock-keyhole
+{% endblock error_icon_mobile_name %}
+{% block error_icon_computer_style %}
+  --fa-primary-color: orange;
+{% endblock error_icon_computer_style %}
+{% block error_icon_mobile_style %}
+  --fa-primary-color: orange;
+{% endblock error_icon_mobile_style %}
+
+{% block error_content %}
+  <p>
+    {% blocktrans trimmed %}
+      CSRF verification failed.
+    {% endblocktrans %}
+  </p>
+{% endblock error_content %}
+
+{% block error_content_help %}
+  <p>
+    {% blocktrans trimmed %}
+      This may be because your session has expired, or there was a problem with the form submission.
+      Please try logging in again.
+    {% endblocktrans %}
+  </p>
+  {{ block.super }}
+{% endblock error_content_help %}


### PR DESCRIPTION
This is the default from Django:
https://docs.djangoproject.com/en/5.1/ref/settings/#csrf-failure-view

I'm actually not sure where these error templates are configured to be used, so not 100% sure it will work.

However, we currently show the default 403 template in prod, which is bad:

<img width="481" alt="Screenshot 2024-11-22 at 8 51 31 AM" src="https://github.com/user-attachments/assets/7a6abd62-15ef-4d43-a652-01b2496a4bec">
