### PR TITLE
Remove weird spacing from titles

### DIFF
--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -4,12 +4,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>
-      {% block title %}
-      {% endblock title %}
-      {% block head_title %}
-      {% endblock head_title %}
-    - Read the Docs</title>
+
+    {# Hide weird spaces in title #}
+    {# djlint:off #}
+    <title>{% block title %}{% endblock title %}{% block head_title %}{% endblock head_title %} - Read the Docs</title>
+    {# djlint:on #}
+
     {% block head_meta %}
       <meta name="description"
             content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />

--- a/readthedocsext/theme/templates/projects/base_dashboard.html
+++ b/readthedocsext/theme/templates/projects/base_dashboard.html
@@ -2,9 +2,9 @@
 
 {% load trans from i18n %}
 
-{% block title %}
-  {% trans "Projects" %}
-{% endblock title %}
+{# djlint:off #}
+{% block title %}{% trans "Projects" %}{% endblock title %}
+{# djlint:on #}
 
 {% block notifications %}
   {# User notifications only #}


### PR DESCRIPTION
This shows up in slack oddly

![Screenshot 2024-12-10 at 8 38 24 AM](https://github.com/user-attachments/assets/9e8500b1-7fe2-4eeb-bcb4-e008b5c6a953)

