### PR TITLE
Extend CSRF 403 from Proxito

### DIFF
--- a/readthedocsext/theme/templates/403_csrf.html
+++ b/readthedocsext/theme/templates/403_csrf.html
@@ -1,1 +1,1 @@
-errors/dashboard/403_csrf.html
+errors/proxito/403_csrf.html

--- a/readthedocsext/theme/templates/errors/proxito/403_csrf.html
+++ b/readthedocsext/theme/templates/errors/proxito/403_csrf.html
@@ -1,4 +1,4 @@
-{% extends "errors/dashboard/403.html" %}
+{% extends "errors/proxito/403.html" %}
 
 {% load blocktrans trans from i18n %}
 


### PR DESCRIPTION
We do trigger CSRF errors from Proxito, so use the more minimal error page.

Fixes https://read-the-docs.sentry.io/issues/6108273096/?project=148442&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=7
