### PR TITLE
Fix member listing page

### DIFF
--- a/readthedocsext/theme/templates/organizations/partials/members_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/members_list.html
@@ -1,10 +1,10 @@
 {% extends "organizations/partials/team_member_list.html" %}
 
-{% load i18n %}
-{% load privacy_tags %}
+{% load trans blocktrans from i18n %}
+{% load is_admin from privacy_tags %}
 
 {% block create_button %}
-{% endblock %}
+{% endblock create_button %}
 
 {% block list_placeholder_header_filtered %}
   {% trans "No matching members found" %}
@@ -20,3 +20,7 @@
     {% endblocktrans %}
   {% endif %}
 {% endblock list_placeholder_text_empty %}
+
+{# Don't show delete button on the member list yet #}
+{% block list_item_right_buttons %}
+{% endblock list_item_right_buttons %}

--- a/readthedocsext/theme/templates/organizations/partials/team_member_list.html
+++ b/readthedocsext/theme/templates/organizations/partials/team_member_list.html
@@ -51,23 +51,26 @@
   {% if is_team_admin is not None and is_team_admin or request.user|org_owner:team %}
     {% url "organization_team_member_delete" organization.slug team.slug object.pk as form_url %}
     {% trans "Remove member" as action_text %}
-    {# Attributes on `object` are proxy methods on TeamMember, this is not a User #}
-    {% blocktrans trimmed asvar content_text with username=object.full_name|default:object.username team=team.name %}
-      Remove user {{ username }} from the team {{ team }}?
+    {# ``object`` is sometimes a :py:class:`TeamMember` and sometimes a :py:class:`User`, but these attributes match on both #}
+    {% firstof object.get_full_name object.username as user_display %}
+    {% blocktrans trimmed asvar content_text with user=user_display team=team.name %}
+      Remove user {{ user }} from the team {{ team }}?
     {% endblocktrans %}
     {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text is_disabled=is_last_user %}
   {% endif %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_image %}
+  {# ``object`` is sometimes a :py:class:`TeamMember` and sometimes a :py:class:`User`, but these attributes match on both #}
+  {% firstof object.get_full_name object.username as user_display %}
   <img class="ui rounded square image"
        src="{% gravatar_url object.email 64 %}"
-       alt="{% blocktrans trimmed with username=object.username %}Profile image for user {{ username }}{% endblocktrans %}" />
+       alt="{% blocktrans trimmed with user=user_display %}Profile image for user {{ user }}{% endblocktrans %}" />
 {% endblock list_item_image %}
 
 {% block list_item_header %}
-  {# Attributes on `object` are proxy methods on TeamMember, this is not a User #}
-  {% with full_name=object.full_name %}
+  {# ``object`` is sometimes a :py:class:`TeamMember` and sometimes a :py:class:`User`, but these attributes match on both #}
+  {% with full_name=object.get_full_name %}
     <a href="{% url "profiles_profile_detail" object.username %}">
 
       {% if full_name %}


### PR DESCRIPTION
The fixes to the team listing page caused new issues on the member listing page, for the same reasons. Both views now show the same -- user full name if available with username underneath, or if no full name just the username.

Last attempt was #546 but this removed the display name on the member listing, which was using the correct attribute names already. readthedocs/readthedocs.org#11861 fixes this discrepancy.

- Requires readthedocs/readthedocs.org#11861