### PR TITLE
Filetreediff: expose it for users that have it enabled

### DIFF
--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -48,6 +48,10 @@
         <a class="item" data-tab="notifications">{% trans "Notifications" %}</a>
         <a class="item" data-tab="analytics">{% trans "Analytics" %}</a>
         <a class="item" data-tab="docdiff">{% trans "Visual diff" %}</a>
+        {# Only show File Tree Diff if it was previously enabled from Django Admin #}
+        {% if form.filetreediff_enabled %}
+          <a class="item" data-tab="filetreediff">{% trans "File tree diff" %}</a>
+        {% endif %}
         <a class="item" data-tab="link-previews">{% trans "Link previews" %}</a>
         <a class="item" data-tab="hotkeys">{% trans "Hotkeys" %}</a>
         <a class="item" data-tab="advanced">{% trans "Advanced" %}</a>
@@ -97,6 +101,15 @@
           {{ form.doc_diff_enabled | as_crispy_field }}
         </div>
       {% endblock addons_docdiff %}
+
+      {% block addons_filetreediff %}
+        {% if form.filetreediff_enabled %}
+          <div class="ui tab" data-tab="filetreediff">
+            {{ form.filetreediff_enabled | as_crispy_field }}
+            {{ form.filetreediff_ignored_files | as_crispy_field }}
+          </div>
+        {% endif %}
+      {% endblock addons_filetreediff %}
 
       {% block addons_link_previews %}
         <div class="ui tab" data-tab="link-previews">

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -48,10 +48,7 @@
         <a class="item" data-tab="notifications">{% trans "Notifications" %}</a>
         <a class="item" data-tab="analytics">{% trans "Analytics" %}</a>
         <a class="item" data-tab="docdiff">{% trans "Visual diff" %}</a>
-        {# Only show File Tree Diff if it was previously enabled from Django Admin #}
-        {% if form.filetreediff_enabled.data is not None %}
-          <a class="item" data-tab="filetreediff">{% trans "File tree diff" %}</a>
-        {% endif %}
+        <a class="item" data-tab="filetreediff">{% trans "File tree diff" %}</a>
         <a class="item" data-tab="link-previews">{% trans "Link previews" %}</a>
         <a class="item" data-tab="hotkeys">{% trans "Hotkeys" %}</a>
         <a class="item" data-tab="advanced">{% trans "Advanced" %}</a>
@@ -103,12 +100,10 @@
       {% endblock addons_docdiff %}
 
       {% block addons_filetreediff %}
-        {% if form.filetreediff_enabled.data is not None %}
-          <div class="ui tab" data-tab="filetreediff">
-            {{ form.filetreediff_enabled | as_crispy_field }}
-            {{ form.filetreediff_ignored_files | as_crispy_field }}
-          </div>
-        {% endif %}
+        <div class="ui tab" data-tab="filetreediff">
+          {{ form.filetreediff_enabled | as_crispy_field }}
+          {{ form.filetreediff_ignored_files | as_crispy_field }}
+        </div>
       {% endblock addons_filetreediff %}
 
       {% block addons_link_previews %}

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -49,7 +49,7 @@
         <a class="item" data-tab="analytics">{% trans "Analytics" %}</a>
         <a class="item" data-tab="docdiff">{% trans "Visual diff" %}</a>
         {# Only show File Tree Diff if it was previously enabled from Django Admin #}
-        {% if form.filetreediff_enabled %}
+        {% if form.filetreediff_enabled.data is not None %}
           <a class="item" data-tab="filetreediff">{% trans "File tree diff" %}</a>
         {% endif %}
         <a class="item" data-tab="link-previews">{% trans "Link previews" %}</a>
@@ -103,7 +103,7 @@
       {% endblock addons_docdiff %}
 
       {% block addons_filetreediff %}
-        {% if form.filetreediff_enabled %}
+        {% if form.filetreediff_enabled.data is not None %}
           <div class="ui tab" data-tab="filetreediff">
             {{ form.filetreediff_enabled | as_crispy_field }}
             {{ form.filetreediff_ignored_files | as_crispy_field }}


### PR DESCRIPTION
We don't expose it to all the users yet, but we want to expose it for those that we already enabled it on the Django Admin.