### PR TITLE
SAML: don't link to the old dashboard

### DIFF
--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -51,7 +51,7 @@
 
       {% if USE_ORGANIZATIONS %}
         <a class="item"
-          href="{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
+           href="{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
           <i class="fas fa-shield-alt icon"></i>
           {% trans "Single sign-on" %}
         </a>

--- a/readthedocsext/theme/templates/account/login.html
+++ b/readthedocsext/theme/templates/account/login.html
@@ -51,8 +51,7 @@
 
       {% if USE_ORGANIZATIONS %}
         <a class="item"
-          {# Link to the old dashboard, since the new dashboard doesn't work for granting access to docs pages yet #}
-          href="https://readthedocs.com{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
+          href="{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
           <i class="fas fa-shield-alt icon"></i>
           {% trans "Single sign-on" %}
         </a>


### PR DESCRIPTION
The form itself will be in charge of redirecting to the old dashboard if needed.

ref https://github.com/readthedocs/readthedocs-corporate/pull/1954