### PR TITLE
fix(jekyll): fix bundler package name

### DIFF
--- a/readthedocsext/theme/templates/projects/import_config.html
+++ b/readthedocsext/theme/templates/projects/import_config.html
@@ -213,7 +213,7 @@ build:
 
   commands:
     # Install dependencies
-    - gem install bundle
+    - gem install bundler
     - bundle install
     # Build the site and save generated files into Read the Docs directory
     - jekyll build --destination $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
The correct package is `bundler` not `bundle`.