### PR TITLE
Improve GHA installation tab

### DIFF
--- a/readthedocsext/theme/templates/profiles/partials/github_app_target_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_app_target_list.html
@@ -1,0 +1,83 @@
+{% extends "includes/crud/table_list.html" %}
+
+{% load trans blocktrans from i18n %}
+
+{% comment rst %}
+  This template is used by the GHA migration template to list GHA
+  installation targets like organization and user accounts.
+
+  :param objects: List of installation target organizations and user accounts
+  :type objects: InstallationTargetGroup
+{% endcomment %}
+
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-code-commit
+{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_header %}
+  {# XXX Why wouldn't the user have organizations or user accounts to install the GHA on here? #}
+  {% blocktrans trimmed %}
+    No installation targets found
+  {% endblocktrans %}
+  <div class="sub header">
+    {% blocktrans trimmed %}
+      You don't have permissions to install our GitHub App on any organizations or user accounts.
+    {% endblocktrans %}
+  </div>
+{% endblock list_placeholder_header %}
+{% block list_placeholder_text %}
+  <a class="ui button"
+     href="?step=revoke"
+     aria-label="{% trans "Skip this step step" %}"
+     target="_blank">{% trans "Skip this step" %}</a>
+{% endblock list_placeholder_text %}
+
+{% block top_right_menu_items %}
+  {% if objects %}
+    <div class="item">
+      <em>
+        {% blocktrans trimmed %}
+          You may need to refresh after installation to continue
+        {% endblocktrans %}
+      </em>
+    </div>
+  {% endif %}
+  <div class="item">
+    <a class="ui small compact primary {% if not objects %}disabled{% endif %} button"
+       href="{{ current_page }}">
+      <i class="fas fa-refresh icon"></i>
+      {% trans "Refresh" %}
+    </a>
+  </div>
+{% endblock top_right_menu_items %}
+
+{% block list_item_meta_items %}
+{% endblock list_item_meta_items %}
+
+{% block list_item_image %}
+  {# XXXX use user/org avatar here #}
+  {% comment %}
+  <img class="ui rounded image" src="{{ object.target_avatar_url }}" height="28" alt="{% trans "Account avatar" %}" width="28" />
+  {% endcomment %}
+{% endblock list_item_image %}
+
+{% block list_item_header %}
+  {{ object.target_name }}
+  <div class="sub header">
+    {# XXX URL? Something else that is helpful? This is just a placeholder, don't actually do this #}
+    https://github.com/{{ object.target_name }}
+  </div>
+{% endblock list_item_header %}
+
+{% block list_item_right_menu %}
+  {% if object.installed %}
+    <div class="ui green text">
+      <i class="fa-solid fa-circle-check icon"></i>
+      {% trans "Installed" %}
+    </div>
+  {% else %}
+    <a href="{{ object.link }}"
+       target="_blank"
+       class="ui small button"
+       data-bind="click: trackLinkClick">{% trans "Install" %}</a>
+  {% endif %}
+{% endblock list_item_right_menu %}

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -175,69 +175,27 @@
                  href="?step=install">{% trans "Next" %}</a>
             {% elif step == "install" %}
               <p>
-                {% blocktrans %}
-                Click on &quot;Install&quot; to install the GitHub App on each account,
-                all the repositories connected to a project will be pre-selected.
+                {% blocktrans trimmed %}
+                  Next, you will install our GitHub App on each organization and account that has attached repositories.
+                  While approving access you will be able to select and deselect individual repositories.
                 {% endblocktrans %}
               </p>
 
-              <div class="ui middle aligned relaxed divided list">
-                {% for installation_target_group in installation_target_groups %}
-                  <div class="item">
-                    <div class="right floated content">
-                      {% if installation_target_group.installed %}
-                        <div class="ui green label">
-                          <i class="fa-solid fa-circle-check icon"></i>
-                          {% trans "Installed" %}
-                        </div>
-                      {% else %}
-                      <a href="{{ installation_target_group.link }}" target="_blank" class="ui small button" data-bind="click: trackLinkClick">
-                          {% trans "Install" %}
-                      </a>
-                      {% endif %}
-                    </div>
-                    <div class="content">
-                      <i class="fa-brands fa-github icon"></i>
-                      <a href="https://github.com/{{ installation_target_group.target_name }}"
-                         target="_blank">
-                        {{ installation_target_group.target_name }}
-                      </a>
-                    </div>
-                  </div>
-                {% empty %}
-                  <div class="item">
-                    <div class="content">
-                      <div class="ui message info">
-                        {% blocktrans trimmed with revoke_step="?step=revoke" %}
-                          You don't have projects to migrate, you can <a href="{{ revoke_step }}">skip this step</a>.
-                        {% endblocktrans %}
-                      </div>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
+              {% include "profiles/partials/github_app_target_list.html" with objects=installation_target_groups %}
 
-              <p>
-                {% blocktrans trimmed with gh_app_name=gh_app_name %}
-                  Alternatively, you can
-                  <a href="https://github.com/apps/{{ gh_app_name }}/installations/new/" data-bind="click: trackLinkClick"
-                     target="_blank">manually install the GitHub App</a>
-                  on each repository you want to migrate, or do it one by one on the next step.
-                {% endblocktrans %}
-              </p>
-
-              <div class="ui message info">
-                <i class="fad fa-info-circle icon"></i>
-                {% blocktrans trimmed with current_page=request.get_full_path migrate_step="?step=migrate" %}
-                  If you see this step as incomplete after installing the GitHub App,
-                  you may need to <a href="{{ current_page }}">refresh this page</a>, or if you don't want to install the GitHub App on all selected repositories,
-                  you can <a href="{{ migrate_step }}">skip this step</a>.
-                {% endblocktrans %}
-              </div>
+              {% if installation_target_groups %}
+                <div class="ui message info">
+                  <i class="fad fa-info-circle icon"></i>
+                  {% blocktrans trimmed %}
+                    If you skip installation during migration, you will need to manually migrate your project to use an account connected through our GitHub App later.
+                  {% endblocktrans %}
+                </div>
+              {% endif %}
 
               <div class="ui divider"></div>
 
               <a class="ui button" href="?step=migrate">{% trans "Next" %}</a>
+              <a class="ui basic button" href="?step=migrate">{% trans "Skip installation and continue" %}</a>
             {% elif step == "migrate" %}
               <p>
                 {% blocktrans %}


### PR DESCRIPTION
- Use less blocks of text and more UI elements
- Use common listing partial for list of installation targets instead of one-off listing structure. This matches the styling we have on all other list of objects as well.
- Use placeholder content area in listing instead of extra blocks of text

Note: I couldn't quite test the install button as it gives me a 404.

### With targets

![image](https://github.com/user-attachments/assets/734be089-e279-4389-bff0-d7e7ad1c6fb0)

### Without targets

![image](https://github.com/user-attachments/assets/95f92095-c332-485a-b1a3-fa84022745d3)
