### PR TITLE
Clean up migration project listing

### DIFF
--- a/readthedocsext/theme/templates/profiles/partials/github_app_project_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_app_project_list.html
@@ -1,0 +1,102 @@
+{% extends "includes/crud/table_list.html" %}
+
+{% load trans blocktrans from i18n %}
+
+{% comment rst %}
+  This template is used by the GHA migration template to list projects to migrate
+{% endcomment %}
+
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-octagon-xmark
+{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_header %}
+  {% blocktrans trimmed %}
+    No projects can be migrated
+  {% endblocktrans %}
+  <div class="sub header">
+    {% blocktrans trimmed %}
+      You don't have any projects to migrate, or you don't have the permissions necessary to migrate your projects to use our GitHub App.
+    {% endblocktrans %}
+  </div>
+{% endblock list_placeholder_header %}
+{% block list_placeholder_text %}
+  <a class="ui button"
+     href="?step=revoke"
+     aria-label="{% trans "Skip this step step" %}"
+     target="_blank">{% trans "Skip this step" %}</a>
+{% endblock list_placeholder_text %}
+
+{% block top_right_menu_items %}
+  {% if objects %}
+    <div class="item">
+      <em>
+        {% blocktrans trimmed %}
+          You may need to manually refresh after installation or migration
+        {% endblocktrans %}
+      </em>
+    </div>
+  {% endif %}
+  <div class="item">
+    <a class="ui small compact primary {% if not objects %}disabled{% endif %} button"
+       href="{{ current_page }}">
+      <i class="fas fa-refresh icon"></i>
+      {% trans "Refresh" %}
+    </a>
+  </div>
+{% endblock top_right_menu_items %}
+
+{% block list_item_image %}
+{% endblock list_item_image %}
+
+{% block list_item_header %}
+  <a href="{% url 'projects_detail' object.project.slug %}"
+     target="_blank">{{ object.project.name }}</a>
+{% endblock list_item_header %}
+
+{% block list_item_right_menu %}
+  {# XXX is this the correct state check required here? #}
+  {% if not object.has_installation and not object.is_admin %}
+    <div data-content="{% trans "You don't have the permissions to install our GitHub App" %}">
+      <button class="ui small disabled negative button">
+        <i class="fas fa-triangle-exclamation icon"></i> {% trans "Install" %}
+      </button>
+    </div>
+  {% elif not object.has_installation %}
+    <a class="ui button small"
+       href="{{ object.installation_link }}"
+       data-bind="click: trackLinkClick"
+       target="_blank">{% trans "Install" %}</a>
+  {% elif not object.can_be_migrated %}
+    {# djlint: off H025 #}
+    {% if not object.is_admin %}
+ 
+      <div data-content="{% trans "Your GitHub user must have admin access to the repository in order to migrate this project" %}">
+      {% else %}
+        {# XXX Why? #} <div data-content="{% trans "This project can't be migrated." %}">
+      {% endif %}
+      {# djlint: on #}
+      <button class="ui small disabled negative button">
+        <i class="fas fa-triangle-exclamation icon"></i>
+        {% trans "Migrate" %}
+      </button>
+    </div>
+  {% else %}
+    <form method="post" action="." class="ui form">
+      {% csrf_token %}
+      <input type="hidden" name="project" value="{{ object.project.slug }}">
+      <button class="ui button small" type="submit">{% trans "Migrate" %}</button>
+    </form>
+  {% endif %}
+{% endblock list_item_right_menu %}
+
+{% block list_item_meta_items %}
+  <div class="item">
+    {% with repo=object.project.remote_repository %}
+      <a href="{{ repo.html_url }}" class="ui small basic image nowrap label">
+        <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
+             src="{{ repo.avatar_url }}" />
+        <code>{{ repo.full_name }}</code>
+      </a>
+    {% endwith %}
+  </div>
+{% endblock list_item_meta_items %}

--- a/readthedocsext/theme/templates/profiles/partials/github_app_project_migrated_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_app_project_migrated_list.html
@@ -1,0 +1,35 @@
+{% extends "profiles/partials/github_app_project_list.html" %}
+
+{% load trans blocktrans from i18n %}
+
+{% comment rst %}
+  This template is used by the GHA migration template to list projects that have been migrated already.
+{% endcomment %}
+
+{% block list_placeholder_icon %}
+{% endblock list_placeholder_icon %}
+{% block list_placeholder_header %}
+  {% blocktrans trimmed %}
+    No projects have been migrated yet
+  {% endblocktrans %}
+  <div class="sub header">
+    {% blocktrans trimmed %}
+      Install our GitHub App and migrate your projects above before proceeding.
+    {% endblocktrans %}
+  </div>
+{% endblock list_placeholder_header %}
+{% block list_placeholder_text %}
+{% endblock list_placeholder_text %}
+
+{% block top_menu %}
+{% endblock top_menu %}
+
+{% block list_item_image %}
+{% endblock list_item_image %}
+
+{% block list_item_right_menu %}
+  <div class="ui green text">
+    <i class="fas fa-circle-check icon"></i>
+    {% trans "Migrated" %}
+  </div>
+{% endblock list_item_right_menu %}

--- a/readthedocsext/theme/templates/profiles/partials/github_app_target_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_app_target_list.html
@@ -1,0 +1,83 @@
+{% extends "includes/crud/table_list.html" %}
+
+{% load trans blocktrans from i18n %}
+
+{% comment rst %}
+  This template is used by the GHA migration template to list GHA
+  installation targets like organization and user accounts.
+
+  :param objects: List of installation target organizations and user accounts
+  :type objects: InstallationTargetGroup
+{% endcomment %}
+
+{% block list_placeholder_icon_class %}
+  fa-duotone fa-code-commit
+{% endblock list_placeholder_icon_class %}
+{% block list_placeholder_header %}
+  {# XXX Why wouldn't the user have organizations or user accounts to install the GHA on here? #}
+  {% blocktrans trimmed %}
+    No installation targets found
+  {% endblocktrans %}
+  <div class="sub header">
+    {% blocktrans trimmed %}
+      You don't have permissions to install our GitHub App on any organizations or user accounts.
+    {% endblocktrans %}
+  </div>
+{% endblock list_placeholder_header %}
+{% block list_placeholder_text %}
+  <a class="ui button"
+     href="?step=revoke"
+     aria-label="{% trans "Skip this step step" %}"
+     target="_blank">{% trans "Skip this step" %}</a>
+{% endblock list_placeholder_text %}
+
+{% block top_right_menu_items %}
+  {% if objects %}
+    <div class="item">
+      <em>
+        {% blocktrans trimmed %}
+          You may need to refresh after installation to continue
+        {% endblocktrans %}
+      </em>
+    </div>
+  {% endif %}
+  <div class="item">
+    <a class="ui small compact primary {% if not objects %}disabled{% endif %} button"
+       href="{{ current_page }}">
+      <i class="fas fa-refresh icon"></i>
+      {% trans "Refresh" %}
+    </a>
+  </div>
+{% endblock top_right_menu_items %}
+
+{% block list_item_meta_items %}
+{% endblock list_item_meta_items %}
+
+{% block list_item_image %}
+  {# XXXX use user/org avatar here #}
+  {% comment %}
+  <img class="ui rounded image" src="{{ object.target_avatar_url }}" height="28" alt="{% trans "Account avatar" %}" width="28" />
+  {% endcomment %}
+{% endblock list_item_image %}
+
+{% block list_item_header %}
+  {{ object.target_name }}
+  <div class="sub header">
+    {# XXX URL? Something else that is helpful? This is just a placeholder, don't actually do this #}
+    https://github.com/{{ object.target_name }}
+  </div>
+{% endblock list_item_header %}
+
+{% block list_item_right_menu %}
+  {% if object.installed %}
+    <div class="ui green text">
+      <i class="fa-solid fa-circle-check icon"></i>
+      {% trans "Installed" %}
+    </div>
+  {% else %}
+    <a href="{{ object.link }}"
+       target="_blank"
+       class="ui small button"
+       data-bind="click: trackLinkClick">{% trans "Install" %}</a>
+  {% endif %}
+{% endblock list_item_right_menu %}

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -198,129 +198,37 @@
               <a class="ui basic button" href="?step=migrate">{% trans "Skip installation and continue" %}</a>
             {% elif step == "migrate" %}
               <p>
-                {% blocktrans %}
-                In order to migrate a project to the new GitHub App,
-                the GitHub App needs to be installed on the repository connected to the project,
-                and you need to have admin access to the repository.
+                {% blocktrans trimmed %}
+                  After installing our GitHub App on each of your repositories,
+                  you will need to migrate your Read the Docs projects to use
+                  the new connection.
                 {% endblocktrans %}
               </p>
 
-              <div class="ui medium header">{% trans "Projects to migrate" %}</div>
+              {% include "profiles/partials/github_app_project_list.html" with objects=migration_targets %}
 
-              <div class="ui middle aligned relaxed divided list">
-                {% for migration_target in migration_targets %}
-                  <div class="item">
-                    <div class="right floated content">
-                      {% if not migration_target.has_installation %}
-                        <a class="ui button small"
-                           href="{{ migration_target.installation_link }}"
-                           data-bind="click: trackLinkClick"
-                           target="_blank">{% trans "Install" %}</a>
-                      {% else %}
-                        <form method="post" action="." class="ui form">
-                          {% csrf_token %}
-                          <input type="hidden"
-                                 name="project"
-                                 value="{{ migration_target.project.slug }}">
-                          <button class="ui button small"
-                                  type="submit"
-                                  {% if not migration_target.is_admin %}disabled{% endif %}>
-                            {% trans "Migrate" %}
-                          </button>
-                        </form>
-                      {% endif %}
-                    </div>
-                    <div class="right floated content">
-                      {% if not migration_target.can_be_migrated %}
-                        <a class="ui orange label"
-                           {% if not migration_target.has_installation %} data-content="{% trans "Install the GitHub App in the repository by clicking on the &quot;Install&quot; button" %}" {% elif not migration_target.is_admin %} data-content="{% trans "You need to have admin access to the repository in order to migrate the project" %} {% endif %}
-                           ">
-                          <i class="fad fa-info-circle icon"></i>
-                          {% trans "Project can't be migrated" %}
-                        </a>
-                      {% endif %}
-                    </div>
-                    <div class="content">
-                      <a class="header"
-                         href="{% url 'projects_detail' migration_target.project.slug %}">
-                        {{ migration_target.project.name }}
-                      </a>
-                      <div class="description">
-                        {% with repo=migration_target.project.remote_repository %}
-                        <a href="{{ repo.html_url }}" class="ui basic image nowrap label">
-                          <img alt="{% blocktrans with name=project.name %}Project {{ name }} avatar{% endblocktrans %}"
-                              src="{{ repo.avatar_url }}" />
-                          <code>{{ repo.full_name }}</code>
-                        </a>
-                        {% endwith %}
-                      </div>
-                    </div>
-                  </div>
-                {% empty %}
-                  <div class="item">
-                    <div class="content">
-                      <div class="ui message info">
-                        {% blocktrans trimmed with revoke_step="?step=revoke" %}
-                          You don't have projects to migrate, you can <a href="{{ revoke_step }}">skip this step</a>.
-                        {% endblocktrans %}
-                      </div>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
               {% if migration_targets %}
-                <p>
-                  {% blocktrans %}
-                  If you want to migrate all projects at once, click on the button below.
-                  Note that projects with warnings will not be migrated.
-                  {% endblocktrans %}
-                </p>
+                <div class="ui segment">
+                  <h3 class="ui small header">{% trans "Migrate all projects" %}</h3>
+                  <p>
+                    {% blocktrans trimmed %}
+                      You can also migrate all projects at once if you don't need to manually review migration for each project.
+                      Note that projects with warnings will not be migrated.
+                    {% endblocktrans %}
+                  </p>
 
-                <form class="ui form" method="post" action=".">
-                  {% csrf_token %}
-                  <button class="ui button" type="submit">{% trans "Migrate all" %}</button>
-                </form>
-
-                <div class="ui message info">
-                  <i class="fad fa-info-circle icon"></i>
-                  {% blocktrans trimmed with current_page=request.get_full_path %}
-                    If you don't see the &quot;Migrate&quot; button and you already installed the GitHub App on the repository,
-                    and have admin access to it,
-                    you may need to <a href="{{ current_page }}">refresh this page</a>.
-                  {% endblocktrans %}
+                  <form class="ui form" method="post" action=".">
+                    {% csrf_token %}
+                    <button class="ui button" type="submit">
+                      {% trans "Migrate all projects" %}
+                    </button>
+                  </form>
                 </div>
-
               {% endif %}
 
-              <div class="ui medium header">
-                {% trans "Projects connected to the GitHub App" %}
-              </div>
+              <div class="ui medium header">{% trans "Projects already migrated" %}</div>
 
-              <div class="ui middle aligned relaxed divided list">
-                {% for project in migrated_projects %}
-                  <div class="item">
-                    <div class="content">
-                      <a class="header" href="{% url 'projects_detail' project.slug %}">
-                        {{ project.name }}
-                      </a>
-                      <div class="description">
-                        <i class="fa-brands fa-github icon"></i>
-                        <a href="{{ project.remote_repository.html_url }}" target="_blank">
-                          {{ project.remote_repository.full_name }}
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                {% empty %}
-                  <div class="item">
-                    <div class="content">
-                      <div class="ui message info">
-                        {% trans "You don't have projects connected to the GitHub App yet." %}
-                      </div>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
+              {% include "profiles/partials/github_app_project_migrated_list.html" with objects=migrated_projects %}
 
               <div class="ui divider"></div>
 

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -175,69 +175,27 @@
                  href="?step=install">{% trans "Next" %}</a>
             {% elif step == "install" %}
               <p>
-                {% blocktrans %}
-                Click on &quot;Install&quot; to install the GitHub App on each account,
-                all the repositories connected to a project will be pre-selected.
+                {% blocktrans trimmed %}
+                  Next, you will install our GitHub App on each organization and account that has attached repositories.
+                  While approving access you will be able to select and deselect individual repositories.
                 {% endblocktrans %}
               </p>
 
-              <div class="ui middle aligned relaxed divided list">
-                {% for installation_target_group in installation_target_groups %}
-                  <div class="item">
-                    <div class="right floated content">
-                      {% if installation_target_group.installed %}
-                        <div class="ui green label">
-                          <i class="fa-solid fa-circle-check icon"></i>
-                          {% trans "Installed" %}
-                        </div>
-                      {% else %}
-                      <a href="{{ installation_target_group.link }}" target="_blank" class="ui small button" data-bind="click: trackLinkClick">
-                          {% trans "Install" %}
-                      </a>
-                      {% endif %}
-                    </div>
-                    <div class="content">
-                      <i class="fa-brands fa-github icon"></i>
-                      <a href="https://github.com/{{ installation_target_group.target_name }}"
-                         target="_blank">
-                        {{ installation_target_group.target_name }}
-                      </a>
-                    </div>
-                  </div>
-                {% empty %}
-                  <div class="item">
-                    <div class="content">
-                      <div class="ui message info">
-                        {% blocktrans trimmed with revoke_step="?step=revoke" %}
-                          You don't have projects to migrate, you can <a href="{{ revoke_step }}">skip this step</a>.
-                        {% endblocktrans %}
-                      </div>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
+              {% include "profiles/partials/github_app_target_list.html" with objects=installation_target_groups %}
 
-              <p>
-                {% blocktrans trimmed with gh_app_name=gh_app_name %}
-                  Alternatively, you can
-                  <a href="https://github.com/apps/{{ gh_app_name }}/installations/new/" data-bind="click: trackLinkClick"
-                     target="_blank">manually install the GitHub App</a>
-                  on each repository you want to migrate, or do it one by one on the next step.
-                {% endblocktrans %}
-              </p>
-
-              <div class="ui message info">
-                <i class="fad fa-info-circle icon"></i>
-                {% blocktrans trimmed with current_page=request.get_full_path migrate_step="?step=migrate" %}
-                  If you see this step as incomplete after installing the GitHub App,
-                  you may need to <a href="{{ current_page }}">refresh this page</a>, or if you don't want to install the GitHub App on all selected repositories,
-                  you can <a href="{{ migrate_step }}">skip this step</a>.
-                {% endblocktrans %}
-              </div>
+              {% if installation_target_groups %}
+                <div class="ui message info">
+                  <i class="fad fa-info-circle icon"></i>
+                  {% blocktrans trimmed %}
+                    If you skip installation during migration, you will need to manually migrate your project to use an account connected through our GitHub App later.
+                  {% endblocktrans %}
+                </div>
+              {% endif %}
 
               <div class="ui divider"></div>
 
               <a class="ui button" href="?step=migrate">{% trans "Next" %}</a>
+              <a class="ui basic button" href="?step=migrate">{% trans "Skip installation and continue" %}</a>
             {% elif step == "migrate" %}
               <p>
                 {% blocktrans %}


### PR DESCRIPTION
- Use partials instead of one off listings
- Reduce text and move to UI elements
- Compact information in table listing and move warnings about installation/migration issues to the button. Show button as disabled when next steps are not possible.
- Use a partial for the second list at the bottom

Relevant commit is be49f17

![image](https://github.com/user-attachments/assets/07c6ee77-0390-4866-8d13-ae474ec13bd2)

This addresses issues with the UI being quite cramped and elements overlapping/wrapping and the UI generally having a bit too much text.

I did not test if pagination would work, I assume not. I don't love having two lists on this UI, it would be better as a singular list instead of two. This would require reworking the logic used, namely the use of dataclasses for each list of objects.
