### PR TITLE
Rename admin dashboard "Git integrations"

### DIFF
--- a/readthedocsext/theme/templates/projects/edit_base.html
+++ b/readthedocsext/theme/templates/projects/edit_base.html
@@ -35,7 +35,7 @@
           <div class="header">{% trans "Building" %}</div>
           <div class="menu">
             <a class="item {% block project_integrations_active %}{% endblock project_integrations_active %}"
-               href="{% url "projects_integrations" project.slug %}">{% trans "Git integrations" %}</a>
+               href="{% url "projects_integrations" project.slug %}">{% trans "Integrations" %}</a>
             <a class="item {% block project_pull_requests_active %}{% endblock project_pull_requests_active %}"
                href="{% url "projects_pull_requests" project.slug %}">{% trans "Pull request builds" %}</a>
             <a class="item {% block project_notifications_active %}{% endblock project_notifications_active %}"


### PR DESCRIPTION
We renamed this to "Git integrations" for some reason, but:

- This feels misleading because these are all webhooks, there is no integration with `git` itself.
- The subpages still all have a heading `Integrations`