### PR TITLE
Some docs on stylesheets and update linting fix to KO hidden pattern

### DIFF
--- a/docs/api/stylesheets.rst
+++ b/docs/api/stylesheets.rst
@@ -1,0 +1,33 @@
+Stylesheets
+===========
+
+This repository uses our base FUI/SUI theme, which is shared with our website.
+
+https://github.com/readthedocs/sui-common-theme/
+
+In this repository, there are some additional styles and elements that are
+specific to our application or that don't need to be defined at our common
+theme. Many of the styles are small bug fixes that don't require additional
+documentation, but there are some styles and new elements that are only found
+and used in this repository.
+
+Utilities
+---------
+
+.. autoanysrc:: hidden
+    :src: ../src/sui/themes/rtd-application/globals/site.overrides
+    :analyzer: css
+
+Images
+------
+
+.. autoanysrc:: images
+    :src: ../src/sui/themes/rtd-application/elements/image.overrides
+    :analyzer: css
+
+Tables
+------
+
+.. autoanysrc:: tables
+    :src: ../src/sui/themes/rtd-application/collections/table.overrides
+    :analyzer: css

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath("."))
 import docext  # noqa
 
 project = "readthedocsext-theme"
-copyright = "2022, Read the Docs, Inc"
+copyright = "2025, Read the Docs, Inc"
 author = "Read the Docs, Inc"
 
 release = "1.0rc1"
@@ -14,6 +14,7 @@ version = release
 
 extensions = [
     "docext",
+    "sphinx.ext.autodoc",
     "sphinxcontrib.autoanysrc",
     "sphinx_js",
 ]
@@ -25,6 +26,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autoanysrc_analyzers = {
     "html": "docext.DjangoTemplateAnalyzer",
+    "css": "docext.CSSAnalyzer",
 }
 
 js_source_path = "../src/js"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Read the Docs -- Application theme
 
    api/templates
    api/javascript
+   api/stylesheets
 
 .. include:: ../README.rst
    :start-line: 3

--- a/readthedocsext/theme/templates/includes/header.html
+++ b/readthedocsext/theme/templates/includes/header.html
@@ -50,7 +50,7 @@ active_item
         <div class="five wide mobile only right aligned column">
           <div class="ui wide dropdown"
                data-bind="semanticui: {dropdown: {action: 'select'}}">
-            {# Ignore "avoid inline styles" rule #}
+            {# Ignore "avoid inline styles" rule. Don't use this hack, this should eventually be a CSS rule instead. #}
             {# djlint:off H021 #}
             <i class="fad fa-bars large icon" style="--fa-secondary-opacity: 0.8;"></i>
             {# djlint:on #}

--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -24,12 +24,8 @@
 {% endblock project_add_configuration %}
 
 {% block project_add_automatic_search %}
-  {# Ignore "avoid inline styles" rule #}
-  {# djlint:off H021 #}
-  <div class="ui small error message"
-       data-bind="visible: error"
-       style="display: none">
-    {# djlint:on #}
+  <div class="ui small error message ko hidden"
+       data-bind="css: {hidden: !error()}">
     {% trans "There was an error while syncing your remote repositories" %}
   </div>
 
@@ -127,12 +123,8 @@
     connected and why the repository can/cannot be used.
 
   {% endcomment %}
-  {# Ignore "avoid inline styles" rule #}
-  {# djlint:off H021 #}
-  <div class="ui fluid card"
-       data-bind="visible: is_selected, with: selected"
-       style="display: none">
-    {# djlint:on #}
+  <div class="ui fluid card ko hidden"
+       data-bind="css: {hidden: !is_selected()}, with: selected">
     <div class="content">
       <img class="ui right floated mini rounded image"
            data-bind="attr: { src: avatar_url }"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,7 @@ install_requires =
 
 [options.extras_require]
 docs =
-    # We can't upgrade Sphinx because of sphinx-js (Sphinx<6)
-    Sphinx<6
-    sphinx_rtd_theme<3
-    sphinxcontrib-autoanysrc<1
-    sphinx-js
+    Sphinx>6
+    sphinx_rtd_theme
+    sphinxcontrib-autoanysrc>=0.2.0
+    sphinx-js>=4

--- a/src/sui/themes/rtd-application/collections/table.overrides
+++ b/src/sui/themes/rtd-application/collections/table.overrides
@@ -1,5 +1,27 @@
-// Build detail page command output table
+/*
+ * Command table variant
+ * =====================
+ *
+ * This is a special table, used solely on the build detail page to list
+ * commands and steps executed. There is some unique CSS rules here to support
+ * command highlighting and ANSI sequences.
+ *
+ * .. code:: html
+ *
+ *     <div class="ui command table">
+ *       ...
+ *     </div>
+ */
 .ui.ui.ui.command.table {
+  /*
+   * Each command is made of up two rows:
+   *
+   * - The first row has two columns, a dropdown expander icon and the
+   *   command executed.
+   * - The second row is normally hidden until collapsed open, it contains
+   *   two columns: the line number and line contents for each line of output in
+   *   STDOUT.
+   */
   tr {
     border-bottom: 0px;
     cursor: unset;
@@ -29,6 +51,16 @@
       word-wrap: anywhere;
     }
 
+    /*
+     * The STDOUT styling supports ANSI color codes through special classes
+     that should be added by the backend exectuion through Docker:
+     *
+     * .. code:: html
+     *
+     *     <span class="ansi-black-fg">...</span>
+     *
+     * .. note:: ANSI sequences are not yet supported by the build backend.
+     */
     &.stdout > code {
       // ansi_up control character classes
       span.ansi-black-fg {

--- a/src/sui/themes/rtd-application/elements/image.overrides
+++ b/src/sui/themes/rtd-application/elements/image.overrides
@@ -1,3 +1,15 @@
+/*
+ * Avatar overlapping variant
+ * ==========================
+ *
+ * Used to create stacking avatar bubbles for maintainer and team member lists.
+ *
+ * .. code:: html
+ *
+ *     <div class="ui overlapping avatar images">
+ *       <img class="ui image" src="..." />
+ *     </div>
+ */
 .ui.overlapping.avatar.images {
   margin-left: 0.25rem;
   > .ui.image,

--- a/src/sui/themes/rtd-application/globals/site.overrides
+++ b/src/sui/themes/rtd-application/globals/site.overrides
@@ -4,14 +4,32 @@
 // chaining more selectors. This rule will override most 3 and 4 selector rules
 // due to the artificially increased specificity in this rule.
 .ko.ko.ko.ko.ko {
-  // There is the Knockout ``visible`` data binding, but this injects a hard
-  // coded style="display: none;" when the binding is false. This makes default
-  // styling on initial load hard with CSS and tends to flash the element to the
-  // user, before the JS loads.
-  //
-  // Instead, something like this is preferable:
-  //
-  //     <div class="ko hidden" data-bind="css: { hidden: !is_showing() }"></div>
+  /*
+   * Knockout ``visible`` binding
+   * ============================
+   *
+   * In standard Knockout there is a ``visible`` data binding, but this
+   * injects a hard coded ``style="display: none;"`` when the binding is false.
+   * This makes default styling on initial load hard with CSS and tends to
+   * flash the element to the user, before the JS loads.
+   *
+   * In standard Knockout, this would look like:
+   *
+   * .. code:: html
+   *
+   *     <div data-bind="visible: is_showing" style="display: none;"></div>
+   *
+   * Using this ``.ko.hidden`` class and the ``css`` binding, this example would instead be:
+   *
+   * .. code:: html
+   *
+   *     <div class="ko hidden" data-bind="css: { hidden: !is_showing() }"></div>
+   *
+   * .. note::
+   *     When used as an observable name, executing the observable as a function
+   *     is not required. In the second example, due to nesting and value negation, we
+   *     have to call the observable as a function, ``is_showing()``.
+   */
   &.hidden {
     display: none;
   }

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv =
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
     PATH={toxinidir}/node_modules/.bin:{env:PATH}
-passenv = CI HOME
+passenv = CI, HOME
 
 [testenv:docs]
 description = Build readthedocsext-theme documentation


### PR DESCRIPTION
This adds some more documentation sourced from our theme styles,
including the pattern we've been using to replace the Knockout
``visible`` binding with a pattern that doesn't need inline styles.

https://read-the-docs-docs-landing--585.com.readthedocs.build/projects/ext-theme/en/585/api/stylesheets.html