### PR TITLE
Link to docs when project is private

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -163,7 +163,9 @@
                   </p>
                   <p class="ui red text"
                      data-bind="visible: !$parent.is_repository_supported($data)">
-                    <a class="ui red mini basic button">{% trans "Read more" %}</a>
+                    <a class="ui red mini basic button"
+                       href="https://docs.readthedocs.com/platform/stable/commercial/"
+                       target="_blank">{% trans "Read more" %}</a>
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
The other page where we talk about private repos is https://docs.readthedocs.com/platform/stable/guides/importing-private-repositories.html, but feels like the commercial page is better suited here.