### PR TITLE
Block integrations page when using GitHub App

### DIFF
--- a/readthedocsext/theme/templates/projects/integration_list.html
+++ b/readthedocsext/theme/templates/projects/integration_list.html
@@ -1,15 +1,35 @@
 {% extends "projects/project_edit_base.html" %}
 
-{% load i18n %}
+{% load trans blocktrans i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Integrations" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Integrations" %}
+{% endblock title %}
 
-{% block project_integrations_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Integrations" %}{% endblock %}
+{% block project_integrations_active %}
+  active
+{% endblock project_integrations_active %}
+{% block project_edit_content_header %}
+  {% trans "Integrations" %}
+{% endblock project_edit_content_header %}
 
 {% block project_edit_content %}
+  {% if project.is_github_app_project %}
+    <div class="ui message icon">
+      <i class="fa-duotone fa-info-circle icon"></i>
+      <div class="content">
+        <div class="header">{% trans "No further configuration needed" %}</div>
+        <p>
+          {% blocktrans trimmed %}
+            This project is already configured to use the <a href="https://readthedocs-landing--12114.org.readthedocs.build/platform/12114/reference/git-integration.html#github-app">GitHub App integration</a>.
+            You don't need to configure any other integrations.
+          {% endblocktrans %}
+        </p>
+      </div>
+    </div>
+  {% endif %}
   {% include "projects/partials/edit/integration_list.html" with objects=object_list %}
-{% endblock %}
+{% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
   {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/connecting-git-account.html" text="How to connect your Read the Docs account to your Git provider" is_external=True class="item" %}

--- a/readthedocsext/theme/templates/projects/integration_list.html
+++ b/readthedocsext/theme/templates/projects/integration_list.html
@@ -21,7 +21,7 @@
         <div class="header">{% trans "No further configuration needed" %}</div>
         <p>
           {% blocktrans trimmed %}
-            This project is already configured to use the <a href="https://readthedocs-landing--12114.org.readthedocs.build/platform/12114/reference/git-integration.html#github-app">GitHub App integration</a>.
+            This project is already configured to use the <a href="https://docs.readthedocs.com/platform/stable/reference/git-integration.html#github-app">GitHub App integration</a>.
             You don't need to configure any other integrations.
           {% endblocktrans %}
         </p>

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -8,7 +8,7 @@
 {% block create_button %}
   {% url "projects_integrations_create" project_slug=project.slug as create_url %}
   {% trans "Add integration" as create_text %}
-  {% include "includes/crud/create_button.html" with url=create_url text=create_text %}
+  {% include "includes/crud/create_button.html" with url=create_url text=create_text is_disabled=project.is_github_app_project %}
 {% endblock create_button %}
 
 {% block list_placeholder_icon_class %}


### PR DESCRIPTION
Needs https://github.com/readthedocs/readthedocs.org/pull/12193

This only blocks the add integration option, so users can still delete existing integrations manually.

![Screenshot 2025-05-19 at 15-53-34 test-builds-stsewd - Integrations - Read the Docs](https://github.com/user-attachments/assets/187b8b41-8797-45b7-9f8f-8bddfa04901b)


ref https://github.com/readthedocs/readthedocs.org/issues/12130