### PR TITLE
Link to "popular documentation tools"

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -24,7 +24,7 @@
   {% trans "You don't have any projects configured yet" %}
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
-  <a href="https://docs.readthedocs.io/page/tutorial/"
+  <a href="https://docs.readthedocs.com/platform/stable/intro/doctools.html"
      target="_blank"
      class="ui primary button">{% trans "Learn how to get started" %}</a>
 {% endblock list_placeholder_text_empty %}


### PR DESCRIPTION
Instead of linking to the tutorial, we are linking to the doctools. That way, the user can immediately know there are a bunch of doctools supported and it's not just Sphinx.

Closes #436