### PR TITLE
GitHub App: open beta

### DIFF
--- a/readthedocsext/theme/templates/profiles/partials/github_oauth_disconnect_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_oauth_disconnect_list.html
@@ -23,7 +23,7 @@
         action="{% url 'socialaccount_connections' %}">
     {% csrf_token %}
     <input type="hidden" name="account" value="{{ object.id }}" />
-    <button class="ui button" type="submit" disabled>
+    <button class="ui disabled button" type="submit">
       <i class="fa-brands fa-github icon"></i>
       {% trans "Disconnect" %}
     </button>

--- a/readthedocsext/theme/templates/profiles/partials/github_oauth_disconnect_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_oauth_disconnect_list.html
@@ -23,7 +23,7 @@
         action="{% url 'socialaccount_connections' %}">
     {% csrf_token %}
     <input type="hidden" name="account" value="{{ object.id }}" />
-    <button class="ui button" type="submit">
+    <button class="ui button" type="submit" disabled>
       <i class="fa-brands fa-github icon"></i>
       {% trans "Disconnect" %}
     </button>

--- a/readthedocsext/theme/templates/profiles/partials/github_oauth_revoke_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_oauth_revoke_list.html
@@ -43,7 +43,7 @@
   {% else %}
     <a href="{{ old_application_link }}"
        target="_blank"
-       class="ui button"
+       class="ui button disabled"
        data-bind="click: trackLinkClick">
       <i class="fa-brands fa-github icon"></i>
       {% trans "Revoke" %}

--- a/readthedocsext/theme/templates/profiles/partials/github_oauth_revoke_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_oauth_revoke_list.html
@@ -43,7 +43,7 @@
   {% else %}
     <a href="{{ old_application_link }}"
        target="_blank"
-       class="ui button disabled"
+       class="ui disabled button"
        data-bind="click: trackLinkClick">
       <i class="fa-brands fa-github icon"></i>
       {% trans "Revoke" %}

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -217,6 +217,13 @@
 
               <a class="ui button" href="?step=revoke">{% trans "Next" %}</a>
             {% elif step == "revoke" %}
+              <div class="ui small warning message">
+                <i class="fad fa-warning icon"></i>
+                {% blocktrans trimmed %}
+                  During the beta period, we don't recommend revoking access to our old GitHub OAuth app.
+                  You will be reminded to complete this step after the beta period ends.
+                {% endblocktrans %}
+              </div>
               <p>
                 {% blocktrans trimmed %}
                   Revoke access to our old GitHub OAuth app.
@@ -240,6 +247,13 @@
               <a class="ui button {% if not step_revoke_completed %}disabled{% endif %}"
                  href="?step=disconnect">{% trans "Next" %}</a>
             {% elif step == "disconnect" %}
+              <div class="ui small warning message">
+                <i class="fad fa-warning icon"></i>
+                {% blocktrans trimmed %}
+                  During the beta period, we don't recommend disconnecting your account from our old GitHub OAuth app.
+                  You will be reminded to complete this step after the beta period ends.
+                {% endblocktrans %}
+              </div>
               <p>
                 {% blocktrans trimmed %}
                   Disconnect the old GitHub OAuth app from your Read the Docs account.

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -224,24 +224,26 @@
                   You will be reminded to complete this step after the beta period ends.
                 {% endblocktrans %}
               </div>
-              <p>
-                {% blocktrans trimmed %}
-                  Revoke access to our old GitHub OAuth app.
-                  You'll be redirected to GitHub, where you need to click on "Revoke access".
-                {% endblocktrans %}
-              </p>
-
-              {% if has_projects_pending_migration and not step_revoke_completed %}
-                <div class="ui small warning message">
-                  <i class="fad fa-warning icon"></i>
-                  {% blocktrans trimmed with migrate_step="?step=migrate" manual_migration_docs="#" %}
-                    You have projects that need to be <a href="{{ migrate_step }}">migrated</a>.
-                    If you revoke access now, you'll need to <a href="{{ manual_migration_docs }}">manually migrate</a> them.
+              <div class="ui disabled basic segment">
+                <p>
+                  {% blocktrans trimmed %}
+                    Revoke access to our old GitHub OAuth app.
+                    You'll be redirected to GitHub, where you need to click on "Revoke access".
                   {% endblocktrans %}
-                </div>
-              {% endif %}
+                </p>
 
-              {% include "profiles/partials/github_oauth_revoke_list.html" with objects=old_github_accounts current_page=request.get_full_path %}
+                {% if has_projects_pending_migration and not step_revoke_completed %}
+                  <div class="ui small warning message">
+                    <i class="fad fa-warning icon"></i>
+                    {% blocktrans trimmed with migrate_step="?step=migrate" manual_migration_docs="#" %}
+                      You have projects that need to be <a href="{{ migrate_step }}">migrated</a>.
+                      If you revoke access now, you'll need to <a href="{{ manual_migration_docs }}">manually migrate</a> them.
+                    {% endblocktrans %}
+                  </div>
+                {% endif %}
+
+                {% include "profiles/partials/github_oauth_revoke_list.html" with objects=old_github_accounts current_page=request.get_full_path %}
+              </div>
 
               <div class="ui divider"></div>
               <a class="ui button {% if not step_revoke_completed %}disabled{% endif %}"
@@ -254,21 +256,23 @@
                   You will be reminded to complete this step after the beta period ends.
                 {% endblocktrans %}
               </div>
-              <p>
-                {% blocktrans trimmed %}
-                  Disconnect the old GitHub OAuth app from your Read the Docs account.
-                {% endblocktrans %}
-              </p>
+              <div class="ui disabled basic segment">
+                <p>
+                  {% blocktrans trimmed %}
+                    Disconnect the old GitHub OAuth app from your Read the Docs account.
+                  {% endblocktrans %}
+                </p>
 
-              <div class="ui message info">
-                <i class="fad fa-info-circle icon"></i>
-                {% blocktrans trimmed with manual_migration_docs="#" %}
-                  After disconnecting the old GitHub OAuth app, you won't be able to see this page again.
-                  If you have projects that need to be migrated, you'll need to <a href="{{ manual_migration_docs }}">manually migrate</a> them.
-                {% endblocktrans %}
+                <div class="ui message info">
+                  <i class="fad fa-info-circle icon"></i>
+                  {% blocktrans trimmed with manual_migration_docs="#" %}
+                    After disconnecting the old GitHub OAuth app, you won't be able to see this page again.
+                    If you have projects that need to be migrated, you'll need to <a href="{{ manual_migration_docs }}">manually migrate</a> them.
+                  {% endblocktrans %}
+                </div>
+
+                {% include "profiles/partials/github_oauth_disconnect_list.html" with objects=old_github_accounts %}
               </div>
-
-              {% include "profiles/partials/github_oauth_disconnect_list.html" with objects=old_github_accounts %}
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
The revoke and disconnect options are not available during the beta, so users can use the old button to log in without any problems. They can still do this from the social accounts list, but if they do so, next time they log in will be redirected to the correct login page, so.

Ref https://github.com/readthedocs/meta/issues/187