### PR TITLE
GitHub App migration page: put migrate all first

### DIFF
--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -193,8 +193,7 @@
                   <h3 class="ui small header">{% trans "Migrate all projects" %}</h3>
                   <p>
                     {% blocktrans trimmed %}
-                      You can also migrate all projects at once if you don't need to manually review migration for each project.
-                      Note that projects with warnings will not be migrated.
+                      Not all projects may be migrated automatically, you might need to take additional steps for some projects.
                     {% endblocktrans %}
                   </p>
 

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -188,8 +188,6 @@
                 {% endblocktrans %}
               </p>
 
-              {% include "profiles/partials/github_app_project_list.html" with objects=migration_targets skip_pagination=True %}
-
               {% if migration_targets %}
                 <div class="ui segment">
                   <h3 class="ui small header">{% trans "Migrate all projects" %}</h3>
@@ -208,6 +206,8 @@
                   </form>
                 </div>
               {% endif %}
+
+              {% include "profiles/partials/github_app_project_list.html" with objects=migration_targets skip_pagination=True %}
 
               <div class="ui medium header">{% trans "Projects already migrated" %}</div>
 

--- a/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
+++ b/readthedocsext/theme/templates/profiles/private/migrate_to_gh_app.html
@@ -193,7 +193,7 @@
                   <h3 class="ui small header">{% trans "Migrate all projects" %}</h3>
                   <p>
                     {% blocktrans trimmed %}
-                      Not all projects may be migrated automatically, you might need to take additional steps for some projects.
+                      You might need to take additional steps for some projects that can't be migrated automatically.
                     {% endblocktrans %}
                   </p>
 


### PR DESCRIPTION
If a user has lots of projects, it's hard to see this option without having to scroll all the way down. But looks weird having this big section before the listing, maybe something like having a "migrate all" link to the actual section is better?

![Screenshot 2025-05-29 at 12-23-48 Migrate account to GitHub App - Read the Docs Dev](https://github.com/user-attachments/assets/fd683aaf-ef01-4000-b960-41dda8461a98)
