### PR TITLE
Update build_name to make it a bit more explicit

### DIFF
--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -33,51 +33,47 @@
 
 {% endcomment %}
 
-{% load i18n %}
+{% from i18n load trans blocktrans %}
 
-{# When not a page title, treat the entire breadcrumb as a link to the build #}
-{% if not is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
-<span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
-  <span class="section">
-      {# When used a a page title, link the sections independently #}
-    {% if is_page_title %}
+{% if is_page_title %}
+  <span class="ui large breadcrumb">
+    <span class="section">
       <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
-    {% endif %}
-
-    {% if build.is_external %}
-      {{ build.external_version_name | lower | capfirst }}
-      {{ build.get_version_name }}
-    {% else %}
-      {# Translators: this renders with the version name, example "Version latest" #}
-      {% blocktrans trimmed with version_name=build.get_version_name %}
-        Version {{ version_name }}
-      {% endblocktrans %}
-    {% endif %}
-
-    {% if is_page_title %}
+        {% if build.is_external %}
+          {{ build.external_version_name | lower | capfirst }}
+          {{ build.get_version_name }}
+        {% else %}
+          {# Translators: this renders with the version name, example "Version latest" #}
+          {% blocktrans trimmed with version_name=build.get_version_name %}
+            Version {{ version_name }}
+          {% endblocktrans %}
+        {% endif %}
       </a>
-    {% endif %}
-  </span>
-  {% if is_page_title %}
-    {# When used as a page title, show a section link for the filtered build list #}
+    </span>
     <span class="divider">/</span>
     {# Translators: this refers to a list of builds for a single project #}
-    <a class="section" href="{% url "builds_project_list" build.project.slug %}?version__slug={{ build.get_version_slug }}">
+    <a class="section"
+       href="{% url "builds_project_list" build.project.slug %}?version__slug={{ build.get_version_slug }}">
       {% trans "Builds" %}
     </a>
-  {% endif %}
-  <span class="divider">/</span>
-  <span class="active section">
-    {% if is_page_title %}
+    <span class="divider">/</span>
+    <span class="active section">
       <a href="{{ build.get_absolute_url }}">
-    {% endif %}
-    <span class="ui grey text">
-      #{{ build.pk }}
-    </span>
-    {% if is_page_title %}
+        <span class="ui grey text">#{{ build.pk }}</span>
       </a>
-    {% endif %}
+    </span>
   </span>
-</span>
-</a>
-{% if not is_page_title %}</a>{% endif %}
+{% else %}
+  <a href="{{ build.get_absolute_url }}">
+    <span class="ui breadcrumb">
+      <span class="active section">
+        <span class="ui grey text">
+          {# Translators: this shows the build number, example "Build #1234" #}
+          {% blocktrans trimmed with build_id=build.pk %}
+            Build #{{ build_id }}
+          {% endblocktrans %}
+        </span>
+      </span>
+    </span>
+  </a>
+{% endif %}

--- a/readthedocsext/theme/templates/builds/partials/build_list.html
+++ b/readthedocsext/theme/templates/builds/partials/build_list.html
@@ -64,7 +64,7 @@
          data-bind="semanticui: { popup: { content: '{{ object.date }}', position: 'top center', delay: { show: 500 }, variation: 'small'}}">
       {# Translators: this will read like "Started 1 month, 3 days ago" #}
       {% blocktrans with object.date|naturaltime as date trimmed %}
-        Started {{ date }}
+        {{ date }}
       {% endblocktrans %}
     </div>
   </div>


### PR DESCRIPTION
This also refactors the logic to have 2 blocks instead of a ton of interspersed if statements,
I find this much easier to read,
though TBH each of these includes is only used once,
so could probably be better off inline in the template instead of as an include.
