### PR TITLE
Changes to support GHA integration

### DIFF
--- a/readthedocsext/theme/templates/includes/components/config_label.html
+++ b/readthedocsext/theme/templates/includes/components/config_label.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load trans from i18n %}
 
 {% comment "rst" %}
   config_label
@@ -32,17 +32,9 @@
 
 {% endcomment %}
 
-<span
-  {% if popup %}
-    data-content="{{ popup }}"
-    aria-label="{{ popup }}"
-  {% endif %}
-  {% if url %}
-    href="{{ url }}"
-  {% endif %}
-  class="ui {% if classes %}{{ classes }} {% endif %}label">
-  {% if icon %}
-    <i class="{{ icon }} icon"></i>
-  {% endif %}
+<span {% if popup %}data-content="{{ popup }}" aria-label="{{ popup }}"{% endif %}
+      {% if url %}href="{{ url }}"{% endif %}
+      class="ui {% if classes %}{{ classes }}{% else %}{% if not text %}icon{% endif %}{% endif %} label">
+  {% if icon %}<i class="{{ icon }} icon"></i>{% endif %}
   {{ text }}
 </span>

--- a/readthedocsext/theme/templates/includes/crud/remove_button.html
+++ b/readthedocsext/theme/templates/includes/crud/remove_button.html
@@ -64,31 +64,34 @@
      data-content="{{ action_text }}">
   <i class="fa-solid fa-trash icon"></i>
 
-  {% comment %}
-    This placement is important, as ``.ui.buttons`` uses :last-child, so we
-    can't place this after the last ``.ui.button``
-  {% endcomment %}
-  <div class="ui {% if warning_text %}tiny{% else %}mini{% endif %} modal"
-       data-modal-id="remove-{{ id }}">
-    <div class="header">{{ action_text }}</div>
-    <div class="content">
-      <p>{{ content_text }}</p>
-      {% if warning_text %}
-        <div class="ui warning message">{{ warning_text }}</div>
-      {% endif %}
-    </div>
-    <div class="actions">
-      <form method="post" action="{{ form_url }}">
-        {% csrf_token %}
-        {% if field_name and field_value %}
-          <input type="hidden" name="{{ field_name }}" value="{{ field_value }}" />
+  {# Avoid rogue modals leaking this UI if the button is disabled #}
+  {% if not is_disabled %}
+    {% comment %}
+      This placement is important, as ``.ui.buttons`` uses :last-child, so we
+      can't place this after the last ``.ui.button``
+    {% endcomment %}
+    <div class="ui {% if warning_text %}tiny{% else %}mini{% endif %} modal"
+         data-modal-id="remove-{{ id }}">
+      <div class="header">{{ action_text }}</div>
+      <div class="content">
+        <p>{{ content_text }}</p>
+        {% if warning_text %}
+          <div class="ui warning message">{{ warning_text }}</div>
         {% endif %}
-        <div class="ui cancel button">{% trans "Cancel" %}</div>
-        <input class="ui button negative"
-               type="submit"
-               value="{{ action_text }}"
-               name="{{ action_name }}">
-      </form>
+      </div>
+      <div class="actions">
+        <form method="post" action="{{ form_url }}">
+          {% csrf_token %}
+          {% if field_name and field_value %}
+            <input type="hidden" name="{{ field_name }}" value="{{ field_value }}" />
+          {% endif %}
+          <div class="ui cancel button">{% trans "Cancel" %}</div>
+          <input class="ui button negative"
+                 type="submit"
+                 value="{{ action_text }}"
+                 name="{{ action_name }}">
+        </form>
+      </div>
     </div>
-  </div>
+  {% endif %}
 </div>

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -36,7 +36,8 @@
 
 {% block list_item_right_buttons %}
   <a class="ui icon button"
-     href="{% url 'projects_integrations_detail' project_slug=project.slug integration_pk=object.pk %}">
+     href="{{ object.get_absolute_url }}"
+     {% if object.is_remote_only %}target="_blank"{% endif %}>
     <i class="fa-duotone fa-wrench icon"></i>
   </a>
 
@@ -45,7 +46,7 @@
   {% blocktrans trimmed asvar content_text with description=object.get_integration_type_display %}
     Remove integration {{ description }}?
   {% endblocktrans %}
-  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text %}
+  {% include "includes/crud/remove_button.html" with id=object.pk form_url=form_url action_text=action_text content_text=content_text is_disabled=object.is_remote_only %}
 {% endblock list_item_right_buttons %}
 
 {% block list_item_icon %}
@@ -53,15 +54,34 @@
 {% endblock list_item_icon %}
 
 {% block list_item_header %}
-  <a href="{% url 'projects_integrations_detail' project_slug=project.slug integration_pk=object.pk %}">
+  <a href="{{ object.get_absolute_url }}"
+     {% if object.is_remote_only %}target="_blank"{% endif %}>
     {{ object.get_integration_type_display }}
   </a>
-  {% if object.has_sync and object.can_sync %}
-    <i class="fa-duotone fa-wand-magic-sparkles icon"
-       data-content="{% trans "Automatically managed" %}"></i>
+
+  {% if object.is_remote_only %}
+    {% blocktrans trimmed asvar popup %}
+      This integration is managed by the provider and cannot be removed
+    {% endblocktrans %}
+    {% include "includes/components/config_label.html" with icon="fa-duotone fa-lock" popup=popup %}
+  {% elif not object.has_sync and not object.can_sync %}
+    {% blocktrans trimmed asvar popup %}
+      This integration is not automatically managed and will require manual setup
+    {% endblocktrans %}
+    {% include "includes/components/config_label.html" with icon="fa-duotone fa-user-gear" popup=popup %}
   {% endif %}
 {% endblock list_item_header %}
 
-{% block list_item_meta %}
-  <div class="item">{{ object.exchanges.count }} exchanges</div>
-{% endblock list_item_meta %}
+{% block list_item_meta_items %}
+  {% if not object.is_active %}
+    {% trans "Disconnected" context "The integration is in a disconnected state" as text %}
+    {% blocktrans trimmed with version=object.verbose_name asvar popup %}
+      This integration is disconnected, check with your provider
+    {% endblocktrans %}
+    <div class="item">
+      {% include "includes/components/config_label.html" with classes="red" icon="fa-solid fa-circle-exclamation" text=text popup=popup %}
+    </div>
+  {% elif not object.is_remote_only %}
+    <div class="item">{{ object.exchanges.count }} exchanges</div>
+  {% endif %}
+{% endblock list_item_meta_items %}


### PR DESCRIPTION
This adds some metadata to the integration display to show GHA
integrations:

- Locked state blocking removal
- Disconnection state on GHA errors
- Links to the GHA page on GitHub for configuration

- Requires https://github.com/readthedocs/readthedocs.org/pull/12273
- Fixes https://github.com/readthedocs/readthedocs.org/issues/12130