### PR TITLE
Build: highlight the name of the version

### DIFF
--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -53,14 +53,14 @@
     {% if build.is_external %}
       <span class="section">
         <span class="divider">/</span>
-        <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
+        {% if is_page_title %}
+          <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
+          {% endif %}
           {{ build.external_version_name | lower | capfirst }}
           {{ build.get_version_name }}
-        </a>
+          {% if is_page_title %}</a>{% endif %}
       </span>
-    {% endif %}
-
-    {% if not build.is_external %}
+    {% else %}
       <span class="section">
         <span class="divider">/</span>
         {% if is_page_title %}

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -38,26 +38,34 @@
 {# When not a page title, treat the entire breadcrumb as a link to the build #}
 {% if not is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
 <span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
+    <span class="section">
+        <span class="ui grey text">
+        {# When used a a page title, link the sections independently #}
+        {% if build.is_external %}
+          {{ build.external_version_name | lower | capfirst }}
+          {{ build.get_version_name }}
+        {% else %}
+        {# Translators: this renders with the version name, example "Version latest" #}
+          {% blocktrans trimmed %}
+            Versions
+          {% endblocktrans %}
+        {% endif %}
+        </span>
+    </span>
+
   <span class="section">
-      {# When used a a page title, link the sections independently #}
-    {% if is_page_title %}
+      <span class="divider">/</span>
+      {% if is_page_title %}
       <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
-    {% endif %}
+      {% endif %}
 
-    {% if build.is_external %}
-      {{ build.external_version_name | lower | capfirst }}
-      {{ build.get_version_name }}
-    {% else %}
-      {# Translators: this renders with the version name, example "Version latest" #}
-      {% blocktrans trimmed with version_name=build.get_version_name %}
-        Version {{ version_name }}
-      {% endblocktrans %}
-    {% endif %}
+          {{ build.get_version_name }}
 
-    {% if is_page_title %}
+      {% if is_page_title %}
       </a>
-    {% endif %}
+      {% endif %}
   </span>
+
   {% if is_page_title %}
     {# When used as a page title, show a section link for the filtered build list #}
     <span class="divider">/</span>

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -39,22 +39,24 @@
 {% if not is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
   <span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
     <span class="section">
-      <span class="ui">
-        {# When used a a page title, link the sections independently #}
-        {# Translators: this renders with the version name, example "Version latest" #}
+      {# When used a a page title, link the sections independently #}
+      {# Translators: this renders with the version name, example "Version latest" #}
+      {% if is_page_title %}
+        <a href="{% url "projects_detail" build.project.slug %}">
+        {% endif %}
         {% blocktrans trimmed %}
           Versions
         {% endblocktrans %}
-      </span>
+        {% if is_page_title %}</a>{% endif %}
     </span>
 
     {% if build.is_external %}
       <span class="section">
         <span class="divider">/</span>
-        <span class="ui">
+        <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
           {{ build.external_version_name | lower | capfirst }}
           {{ build.get_version_name }}
-        </span>
+        </a>
       </span>
     {% endif %}
 

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -39,30 +39,37 @@
 {% if not is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
   <span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
     <span class="section">
-      <span class="ui grey text">
+      <span class="ui">
         {# When used a a page title, link the sections independently #}
-        {% if build.is_external %}
-          {{ build.external_version_name | lower | capfirst }}
-          {{ build.get_version_name }}
-        {% else %}
-          {# Translators: this renders with the version name, example "Version latest" #}
-          {% blocktrans trimmed %}
-            Versions
-          {% endblocktrans %}
-        {% endif %}
+        {# Translators: this renders with the version name, example "Version latest" #}
+        {% blocktrans trimmed %}
+          Versions
+        {% endblocktrans %}
       </span>
     </span>
 
-    <span class="section">
-      <span class="divider">/</span>
-      {% if is_page_title %}
-        <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
-        {% endif %}
+    {% if build.is_external %}
+      <span class="section">
+        <span class="divider">/</span>
+        <span class="ui">
+          {{ build.external_version_name | lower | capfirst }}
+          {{ build.get_version_name }}
+        </span>
+      </span>
+    {% endif %}
 
-        {{ build.get_version_name }}
+    {% if not build.is_external %}
+      <span class="section">
+        <span class="divider">/</span>
+        {% if is_page_title %}
+          <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
+          {% endif %}
 
-        {% if is_page_title %}</a>{% endif %}
-    </span>
+          {{ build.get_version_name }}
+
+          {% if is_page_title %}</a>{% endif %}
+      </span>
+    {% endif %}
 
     {% if is_page_title %}
       {# When used as a page title, show a section link for the filtered build list #}

--- a/readthedocsext/theme/templates/builds/includes/build_name.html
+++ b/readthedocsext/theme/templates/builds/includes/build_name.html
@@ -33,59 +33,51 @@
 
 {% endcomment %}
 
-{% load i18n %}
+{% load trans blocktrans from i18n %}
 
 {# When not a page title, treat the entire breadcrumb as a link to the build #}
 {% if not is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
-<span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
+  <span class="ui {% if is_page_title %}large{% endif %} breadcrumb">
     <span class="section">
-        <span class="ui grey text">
+      <span class="ui grey text">
         {# When used a a page title, link the sections independently #}
         {% if build.is_external %}
           {{ build.external_version_name | lower | capfirst }}
           {{ build.get_version_name }}
         {% else %}
-        {# Translators: this renders with the version name, example "Version latest" #}
+          {# Translators: this renders with the version name, example "Version latest" #}
           {% blocktrans trimmed %}
             Versions
           {% endblocktrans %}
         {% endif %}
-        </span>
+      </span>
     </span>
 
-  <span class="section">
+    <span class="section">
       <span class="divider">/</span>
       {% if is_page_title %}
-      <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
-      {% endif %}
+        <a href="{% url "projects_detail" build.project.slug %}?slug={{ build.get_version_slug }}">
+        {% endif %}
 
-          {{ build.get_version_name }}
+        {{ build.get_version_name }}
 
-      {% if is_page_title %}
-      </a>
-      {% endif %}
-  </span>
-
-  {% if is_page_title %}
-    {# When used as a page title, show a section link for the filtered build list #}
-    <span class="divider">/</span>
-    {# Translators: this refers to a list of builds for a single project #}
-    <a class="section" href="{% url "builds_project_list" build.project.slug %}?version__slug={{ build.get_version_slug }}">
-      {% trans "Builds" %}
-    </a>
-  {% endif %}
-  <span class="divider">/</span>
-  <span class="active section">
-    {% if is_page_title %}
-      <a href="{{ build.get_absolute_url }}">
-    {% endif %}
-    <span class="ui grey text">
-      #{{ build.pk }}
+        {% if is_page_title %}</a>{% endif %}
     </span>
+
     {% if is_page_title %}
+      {# When used as a page title, show a section link for the filtered build list #}
+      <span class="divider">/</span>
+      {# Translators: this refers to a list of builds for a single project #}
+      <a class="section"
+         href="{% url "builds_project_list" build.project.slug %}?version__slug={{ build.get_version_slug }}">
+        {% trans "Builds" %}
       </a>
     {% endif %}
+    <span class="divider">/</span>
+    <span class="active section">
+      {% if is_page_title %}<a href="{{ build.get_absolute_url }}">{% endif %}
+        <span class="ui grey text">#{{ build.pk }}</span>
+        {% if is_page_title %}</a>{% endif %}
+    </span>
   </span>
-</span>
-</a>
-{% if not is_page_title %}</a>{% endif %}
+  {% if not is_page_title %}</a>{% endif %}


### PR DESCRIPTION
I find pretty hard to know what's the version of the current build on the build details' page, so I want to make it more visible.

I'm following the same style/pattern we are following for the build id and I like it.

![Screenshot_2025-07-07_12-50-18](https://github.com/user-attachments/assets/facf70e5-7d38-485f-b74f-c94b8b3e8186)
