### PR TITLE
Link to redirect creation page when editing a version

### DIFF
--- a/readthedocsext/theme/templates/projects/version_form.html
+++ b/readthedocsext/theme/templates/projects/version_form.html
@@ -53,7 +53,11 @@
           <div class="content">
             {% if version.active %}
               <div class="ui warning message">
-                {% trans "Deactivating a version or changing its slug will result in the deletion of its documentation." %}
+                {% url "projects_redirects_create" project_slug=project.slug as url_redirects %}
+                {% blocktrans trimmed with url=url_redirects %}
+                  Deactivating a version or changing its slug will result in the deletion of its documentation.
+                  Make sure to <a href="{{ url }}" target="_blank">create a redirect</a> to avoid not found pages.
+                {% endblocktrans %}
               </div>
             {% endif %}
 

--- a/readthedocsext/theme/templates/projects/version_form.html
+++ b/readthedocsext/theme/templates/projects/version_form.html
@@ -56,7 +56,7 @@
                 {% url "projects_redirects_create" project_slug=project.slug as url_redirects %}
                 {% blocktrans trimmed with url=url_redirects %}
                   Deactivating a version or changing its slug will result in the deletion of its documentation.
-                  Make sure to <a href="{{ url }}" target="_blank">create a redirect</a> to avoid not found pages.
+                  Make sure to <a href="{{ url }}" target="_blank">create a redirect</a> for these URLs to ensure old links continue working.
                 {% endblocktrans %}
               </div>
             {% endif %}


### PR DESCRIPTION
This is implements the idea 4) from
https://github.com/readthedocs/readthedocs.org/issues/11978 as a first step.

However, we can get fancier here and automate this creation somehow if we want. There are more ideas for UX in that issue.