### PR TITLE
Avoid calling .exists twice in the same query

### DIFF
--- a/readthedocsext/theme/templates/includes/crud/table_list.html
+++ b/readthedocsext/theme/templates/includes/crud/table_list.html
@@ -1,3 +1,4 @@
+{% load is_empty from ext_theme_tags %}
 {% comment "rst" %}
   Shared list base
   ================
@@ -92,21 +93,16 @@
   {% comment %}
     We usually pass in a queryset here, but some views emit arrays of objects
     instead, so we support these as well. Therefore, the check here needs to be
-    for an empty array or an empty queryset. Because Django templates aim to
-    be as difficult as possible to use, this conditional looks pretty silly.
+    for an empty array or an empty queryset.
 
-    This cannot be a simple `if not objects` as this executes the query, which
-    can cause the view to timeout when the query is very large. See ``bool``
-    evaluation in:
+    We avoid using a simple `if not objects` check, as that would evaluate
+    the queryset, which can cause a timeout if the queryset is very large,
+    instead we use a custom template tag that call ``exists`` if the value is
+    a queryset, or ``not value`` otherwise. See ``bool`` evaluation in:
 
     https://docs.djangoproject.com/en/4.2/ref/models/querysets/
-
-    Order on the conditional matters here, `and` has higher precedence. Django
-    templates don't support parenthesis in conditionals.
-
-    https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#boolean-operators
   {% endcomment %}
-  {% if objects.exists is None and objects|length == 0 or objects.exists == False %}
+  {% if objects|is_empty %}
     {% comment "rst" %}
 
       .. _api-template-list-placeholder:

--- a/readthedocsext/theme/templatetags/ext_theme_tags.py
+++ b/readthedocsext/theme/templatetags/ext_theme_tags.py
@@ -1,6 +1,8 @@
 import logging
 from urllib.parse import urljoin
 
+from django.db.models.query import QuerySet
+
 from django import template
 from django.conf import settings
 from django.templatetags.i18n import (
@@ -211,3 +213,15 @@ def readthedocs_language_name_local(lang_code):
     except Exception:
         log.exception("Error getting language name")
         return lang_code
+
+
+@register.filter
+def is_empty(value):
+    """
+    Check if an iterable or queryset is empty.
+
+    This avoids using `not value` on a queryset, so the queryset is not evaluated.
+    """
+    if isinstance(value, QuerySet):
+        return not value.exists()
+    return not value


### PR DESCRIPTION
If the object to check was a queryset, exist would be called twice. Instead of dealing with checks in the template, I'm just using a filter.

Tests on .org will need to be updated after this is merged to reduce the expected queries.