### PR TITLE
Autopaginate fewer objects

### DIFF
--- a/readthedocsext/theme/templates/includes/crud/list.html
+++ b/readthedocsext/theme/templates/includes/crud/list.html
@@ -228,7 +228,7 @@
         <div class="{% block list_classes %}ui middle aligned very relaxed divided list{% endblock %}">
 
           {% if not skip_pagination %}
-            {% autopaginate objects 15 %}
+            {% autopaginate objects 5 %}
           {% endif %}
 
           {% for object in objects %}

--- a/readthedocsext/theme/templates/includes/crud/table_list.html
+++ b/readthedocsext/theme/templates/includes/crud/table_list.html
@@ -320,7 +320,7 @@
         <table class="{% block list_classes %}ui very basic stacking table{% endblock list_classes %}">
 
           {% if not skip_pagination %}
-            {% autopaginate objects 15 %}
+            {% autopaginate objects 5 %}
           {% endif %}
 
           <tbody>


### PR DESCRIPTION
This makes pagination not break on mobile,
and 15 is too many items for something that most users will never use?
