### PR TITLE
Webpack: use filesystem cache for compilation

### DIFF
--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -59,7 +59,7 @@ export default (env, argv) => {
     // Use filesystem for cache instead memory (default) to be re-use the cache
     // between Docker container starts/stops. This speeds up boot time a lot.
     cache: {
-      type: "filesystem",
+      type: is_production ? "memory" : "filesystem",
     },
 
     module: {


### PR DESCRIPTION
This allows to speed up webpack start. It went from 8s to 1s in my laptop after the initial compilation.

By default, webpack uses memory cache, but it's deleted once the container is shut down. Keeping the cache in the filesystem allows the container to reuse the cached resources.