### PR TITLE
Don't log the exception for language code issues

### DIFF
--- a/readthedocsext/theme/templatetags/ext_theme_tags.py
+++ b/readthedocsext/theme/templatetags/ext_theme_tags.py
@@ -189,7 +189,7 @@ def readthedocs_language_name(lang_code):
             return language_name("zh-cn")
         return language_name(lang_code)
     except Exception:
-        log.exception("Error getting language name")
+        log.debug(f"Unknown language code: {lang_code}")
         return lang_code
 
 


### PR DESCRIPTION
This fills up Sentry, and we don't need them.
