### PR TITLE
Make external links nofollow.

### DIFF
--- a/readthedocsext/theme/templates/includes/elements/link.html
+++ b/readthedocsext/theme/templates/includes/elements/link.html
@@ -31,7 +31,7 @@
 
 <a href="{{ url }}"
    class="{{ class }}"
-   {% if is_external %}target="_blank" rel="nofollow"{% endif %}
+   {% if is_external %}target="_blank" rel="nofollow noopener noreferrer"{% endif %}
    {% if label %}data-content="{{ label }}" aria-label="{{ label }}"{% endif %}>
   {{ text }}
   {% if is_external %}


### PR DESCRIPTION
This was causing us to get spammed.

I'm a little confused why `link.html` even exists -- it seems it's only used on the profile card page, and made following this logic harder. 