### PR TITLE
Add links to Addons documentation

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
@@ -25,10 +25,12 @@
     {% blocktrans trimmed %}
       Traffic data will be accumulated as readers view your documentation.
     {% endblocktrans %}
-    {% url 'projects_addons' project.slug as addons_url %}
-    {% blocktrans with url=addons_url trimmed %}
-      Traffic analytics must be enabled in your project's <a href="{{ url }}">Addons settings</a>.
-    {% endblocktrans %}
+    {% if show_addons_link %}
+      {% url 'projects_addons' project.slug as addons_url %}
+      {% blocktrans with url=addons_url trimmed %}
+        Traffic analytics must be enabled in your project's <a href="{{ url }}">Addons settings</a>.
+      {% endblocktrans %}
+    {% endif %}
   </div>
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/traffic_analytics.html
+++ b/readthedocsext/theme/templates/projects/traffic_analytics.html
@@ -26,7 +26,7 @@
   <div class="{% if not enabled %}ui basic fitted disabled segment{% endif %}"
        data-bind="using: ProjectTrafficAnalyticsView()">
 
-    {% include "projects/partials/edit/traffic_list.html" with objects=top_pages_200 %}
+    {% include "projects/partials/edit/traffic_list.html" with objects=top_pages_200 show_addons_link=True %}
 
     {% if top_pages_200 %}
       <h3 class="ui small header">


### PR DESCRIPTION
This also makes the Analytics pages not show download buttons or graphs with no data.
This feels much cleaner.

Old

<img width="625" height="662" alt="Screenshot 2025-10-30 at 8 12 28 AM" src="https://github.com/user-attachments/assets/630e03dd-5aa9-41a7-b26d-e5cccd07a61e" />


New

<img width="725" height="391" alt="Screenshot 2025-10-30 at 8 11 46 AM" src="https://github.com/user-attachments/assets/5494dbef-f9f0-4936-abe4-ce8c612f4688" />
