### PR TITLE
Don't allow adding domains on subprojects

### DIFF
--- a/readthedocsext/theme/templates/projects/domain_list.html
+++ b/readthedocsext/theme/templates/projects/domain_list.html
@@ -1,6 +1,6 @@
 {% extends "projects/project_edit_base.html" %}
 
-{% load trans from i18n %}
+{% load trans blocktrans from i18n %}
 
 {% block title %}
   {{ project.name }} - {% trans "Domains" %}
@@ -23,8 +23,24 @@
   {% endcomment %}
   {% if not enabled %}
     {% include "organizations/includes/feature_disabled.html" with project=project plan="Advanced" %}
+  {% elif project.superproject %}
+    <div class="ui icon message">
+      <i class="fa-duotone fa-circle-exclamation icon"></i>
+      <div class="content">
+        <div class="header">{% trans "Custom domains managed by superproject" %}</div>
+        <p>
+          {% url "projects_detail" project.superproject.slug as superproject_url %}
+          {% url "projects_domains" project.superproject.slug as superproject_domains_url %}
+          {% blocktrans trimmed with superproject_url=superproject_url superproject_domains_url=superproject_domains_url superproject_name=project.superproject.name %}
+            This project is a subproject of
+            <a href="{{ superproject_url }}">{{ superproject_name }}</a>.
+            Custom domains must be <a href="{{ superproject_domains_url }}">added on the superproject</a>.
+          {% endblocktrans %}
+        </p>
+      </div>
+    </div>
   {% endif %}
-  <div class="{% if not enabled %}ui basic fitted disabled segment{% endif %}">
+  <div class="{% if not enabled or project.superproject %}ui basic fitted disabled segment{% endif %}">
     {% include "projects/partials/edit/domain_list.html" with objects=object_list %}
   </div>
 {% endblock project_edit_content %}


### PR DESCRIPTION
This action isn't allowed at the form level, it gives a generic error, as it was expecting the UI to block this action, so users won't get this error.

I also noticed that we are blocking the whole list, but we only want to block the "add" action, as users could have had domains already created, we still want users to be able to delete those.

<img width="1205" height="487" alt="Screenshot 2025-11-05 at 11-58-42 subproject - Domains - Read the Docs Dev" src="https://github.com/user-attachments/assets/6296c201-347c-4a56-88a8-08658f371e61" />


closes https://github.com/readthedocs/ext-theme/issues/666