### PR TITLE
Sharing: show last used timestamp for temporary access

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
@@ -104,4 +104,16 @@
       <div class="description">{{ object.expires }}</div>
     </div>
   </div>
+  <div class="item">
+    <div class="content">
+      <div class="header">{% trans "Last used" %}</div>
+      <div class="description">
+        {% if object.last_used_at %}
+          {{ object.last_used_at|timesince }}
+        {% else %}
+          {% trans "Never" %}
+        {% endif %}
+      </div>
+    </div>
+  </div>
 {% endblock list_item_extra_items %}


### PR DESCRIPTION

<img width="792" height="292" alt="Screenshot_2025-12-12_11-38-27" src="https://github.com/user-attachments/assets/02017185-b6f0-41f4-b6e4-9ee482df572c" />


Requires: https://github.com/readthedocs/readthedocs-corporate/pull/2073