### PR TITLE
Connected services: add actions related to GH App

### DIFF
--- a/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
+++ b/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
@@ -44,21 +44,23 @@
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_menu %}
-  <div class="ui small icon buttons">
-    {% if object.get_provider.id == "github" %}
+  {% if object.get_provider.id == "github" %}
+    <div class="ui small buttons">
       {% if object|has_github_app_account %}
-        <a class="ui icon button"
+        <a class="ui secondary button"
            data-content="{% trans "Complete migration to GitHub App" %}"
            href="{% url "migrate_to_github_app" %}"
-           target="_blank">Migrate</a>
+           target="_blank">{% trans "Migrate" %}</a>
       {% else %}
-        <a class="ui icon button"
+        <a class="ui secondary button"
            data-content="{% trans "Migrate to GitHub App" %}"
            href="{% url "migrate_to_github_app" %}"
-           target="_blank">Migrate</a>
+           target="_blank">{% trans "Migrate" %}</a>
       {% endif %}
-    {% endif %}
+    </div>
+  {% endif %}
 
+  <div class="ui small icon buttons">
     {% if object.get_provider.id == "githubapp" %}
       <a class="ui icon button"
          data-content="{% trans "Manage GitHub App on GitHub" %}"


### PR DESCRIPTION
Closes https://github.com/readthedocs/ext-theme/pull/655

Closes https://github.com/readthedocs/ext-theme/issues/583

I'm not sure if this is the best way to show users that they need to migrate or complete the migration. I think it's better if we just show an info alert at the top? A button in the integration listing feels weird. The manage action looks okay.

<img width="826" height="373" alt="Screenshot 2025-12-17 at 22-16-16 Connected services - Read the Docs Dev" src="https://github.com/user-attachments/assets/ea46a200-104b-49b3-8eeb-72f525effafd" />
