### PR TITLE
Forms: don't treat errors as safe strings

### DIFF
--- a/readthedocsext/theme/templates/semantic-ui/errors.html
+++ b/readthedocsext/theme/templates/semantic-ui/errors.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load trans from i18n %}
 
 {% if form.errors and form.non_field_errors %}
   {% for error in form.non_field_errors %}


### PR DESCRIPTION
We usually include user input in error messages, they shouldn't be considered safe. If forms want to include HTML, they should be able to do so using format_html, or mark_safe (django templates do this).

NOTE: While this is a vulnerability, in order to be exploited the user needs to enter the malicious payload into a form that will trigger a global error, so this is a self-xss that requires manual user interaction. We also currently don't expose any form that can trigger global errors with uncontrolled user input. So I'm making this fix public and without an advisory.

More info at https://readthedocs.slack.com/archives/C04SS8XNB6K/p1768259858889249