### PR TITLE
Automation rules: remove extra period

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
@@ -28,7 +28,7 @@
 {% block list_placeholder_text %}
   <a class="ui button"
      target="_blank"
-     href="https://docs.readthedocs.io/page/automation-rules.html">{% trans "Learn more" %}</a>.
+     href="https://docs.readthedocs.io/page/automation-rules.html">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}


### PR DESCRIPTION
This is a button, it doesn't need a period to end the sentence

<img width="759" height="288" alt="image" src="https://github.com/user-attachments/assets/8d241845-e6a7-4b79-838e-184d44606046" />
