### PR TITLE
GitHub App migration: don't disable revoke button

### DIFF
--- a/readthedocsext/theme/templates/profiles/partials/github_oauth_revoke_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_oauth_revoke_list.html
@@ -43,7 +43,7 @@
   {% else %}
     <a href="{{ old_application_link }}"
        target="_blank"
-       class="ui disabled button"
+       class="ui button"
        data-bind="click: trackLinkClick">
       <i class="fa-brands fa-github icon"></i>
       {% trans "Revoke" %}


### PR DESCRIPTION
Forgot to remove this