### PR TITLE
Build: show `builder` where the build was executed

### DIFF
--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -96,6 +96,16 @@
                   </div>
                 </div>
 
+                {% if request.user.is_superuser %}
+                  <div class="item">
+                    <i class="grey fa-duotone fa-helmet-safety icon"></i>
+                    <div class="content">
+                      <span class="sub header">{% trans "Builder" %}</span>
+                      <span data-bind="text: builder"></span>
+                    </div>
+                  </div>
+                {% endif %}
+
               </div>
             </div>
           {% endblock build_detail_metadata_right %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -101,7 +101,7 @@
                     <i class="grey fa-duotone fa-helmet-safety icon"></i>
                     <div class="content">
                       <span class="sub header">{% trans "Builder" %}</span>
-                      <span data-bind="text: builder"></span>
+                      <span>{{ build.builder }}</span>
                     </div>
                   </div>
                 {% endif %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -96,16 +96,6 @@
                   </div>
                 </div>
 
-                {% if request.user.is_superuser or request.user.is_impersonate %}
-                  <div class="item">
-                    <i class="grey fa-duotone fa-helmet-safety icon"></i>
-                    <div class="content">
-                      <span class="sub header">{% trans "Builder" %}</span>
-                      <span>{{ build.builder }}</span>
-                    </div>
-                  </div>
-                {% endif %}
-
               </div>
             </div>
           {% endblock build_detail_metadata_right %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -96,7 +96,7 @@
                   </div>
                 </div>
 
-                {% if request.user.is_superuser %}
+                {% if request.user.is_superuser or request.user.is_impersonate %}
                   <div class="item">
                     <i class="grey fa-duotone fa-helmet-safety icon"></i>
                     <div class="content">

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -185,7 +185,7 @@ collapsed, to save visual space and can be expanded with the right label.
           </a>
         {% endif %}
         {% if request.user|is_admin:project %}
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff or request.user.is_impersonate %}
             <a class="item" data-bind="click: $root.show_modal('project-debug')">
               <i class="fa-duotone fa-microscope icon"></i>
               {% trans "Debug" %}
@@ -200,7 +200,7 @@ collapsed, to save visual space and can be expanded with the right label.
       </div>
     </div>
 
-    {% if request.user.is_staff %}
+    {% if request.user.is_staff or request.user.is_impersonate %}
       <div class="ui mini modal" data-modal-id="project-debug">
         <div class="header">{% trans "Debug information" %}</div>
         {% comment %}
@@ -220,6 +220,22 @@ collapsed, to save visual space and can be expanded with the right label.
                  target="_blank">{% trans "View project changelist filtered by slug" %}</a>
             </div>
           </div>
+
+          {% if build %}
+            <h3>{% trans "Build" %}</h3>
+            <div class="ui vertical list">
+              <div class="item">
+                <div class="ui sub header">{% trans "Builder" %}</div>
+                <span>{{ build.builder }}</span>
+              </div>
+              {% if request.user.is_staff %}
+                <div class="item">
+                  <a href="{{ ADMIN_URL }}/builds/build/{{ build.pk }}/change/"
+                     target="_blank">{% trans "View build in Django admin" %}</a>
+                </div>
+              {% endif %}
+            </div>
+          {% endif %}
 
           {% if not USE_ORGANIZATIONS %}
             <h3>{% trans "Spam" %}</h3>

--- a/readthedocsext/theme/templates/projects/partials/header.html
+++ b/readthedocsext/theme/templates/projects/partials/header.html
@@ -228,12 +228,10 @@ collapsed, to save visual space and can be expanded with the right label.
                 <div class="ui sub header">{% trans "Builder" %}</div>
                 <span>{{ build.builder }}</span>
               </div>
-              {% if request.user.is_staff %}
-                <div class="item">
-                  <a href="{{ ADMIN_URL }}/builds/build/{{ build.pk }}/change/"
-                     target="_blank">{% trans "View build in Django admin" %}</a>
-                </div>
-              {% endif %}
+              <div class="item">
+                <a href="{{ ADMIN_URL }}/builds/build/{{ build.pk }}/change/"
+                   target="_blank">{% trans "View build in Django admin" %}</a>
+              </div>
             </div>
           {% endif %}
 


### PR DESCRIPTION
This is a feature we had in the previous dashboard, but we lost it in the migration.

It's pretty useful when debugging support request and I'd like to have it back.

<img width="644" height="550" alt="Screenshot_2026-02-24_11-55-19" src="https://github.com/user-attachments/assets/a365596a-c4a5-41be-8a38-fcedeb4d7843" />


~~Requires https://github.com/readthedocs/readthedocs.org/pull/12810~~