### PR TITLE
Migrate documentation URLs to docs.readthedocs.com

### DIFF
--- a/readthedocsext/theme/templates/account/signup.html
+++ b/readthedocsext/theme/templates/account/signup.html
@@ -55,8 +55,8 @@
 {% block authentication_extra %}
   <p class="ui center aligned tiny basic vertically fitted basic cleared segment">
     {% blocktrans trimmed %}
-      By signing up for an account, you agree to our <a href="https://docs.readthedocs.io/page/terms-of-service.html"
-    target="_blank">Terms of Service</a> and <a href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>.
+      By signing up for an account, you agree to our <a href="https://docs.readthedocs.com/platform/stable/terms-of-service.html"
+    target="_blank">Terms of Service</a> and <a href="https://docs.readthedocs.com/platform/stable/privacy-policy.html">Privacy Policy</a>.
     {% endblocktrans %}
   </p>
 {% endblock authentication_extra %}

--- a/readthedocsext/theme/templates/homepage.html
+++ b/readthedocsext/theme/templates/homepage.html
@@ -112,14 +112,16 @@
   <!-- Call to action -->
   <div class="ui inverted segment basic center aligned very padded">
     <div class="ui container">
-      <a href="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html"
+      <a href="https://docs.readthedocs.com/platform/stable/intro/sphinx.html"
          target="_blank"
          class="ui button primary">{% trans "Getting started guide" %}</a>
     </div>
   </div>
 
   <!-- Search -->
-  <div class="ui container very padded">{# include "includes/widesearchbar.html" #}</div>
+  <div class="ui container very padded">
+    {# include "includes/widesearchbar.html" #}
+  </div>
 
   {% if featured_list %}
     {% comment %}
@@ -166,7 +168,9 @@
   <!-- Funding and Contributing -->
   <section class="ui basic segment very padded">
     <div class="ui container">
-      <h2 class="ui header center aligned">{% trans "Read the Docs is funded by the community" %}</h2>
+      <h2 class="ui header center aligned">
+        {% trans "Read the Docs is funded by the community" %}
+      </h2>
       <p>
 
         {% url "advertising" as advertising_url %}
@@ -187,10 +191,11 @@
         {% blocktrans trimmed %}
           Read the Docs is <strong>community supported</strong>.
           It depends on users like you to contribute to development, support, and operations.
-          You can learn more about how to <a href="https://docs.readthedocs.io/page/contribute.html"
+          You can learn more about how to <a href="https://docs.readthedocs.com/platform/stable/contribute.html"
     target="_blank">contribute</a> in our
           docs.
-          Thanks so much to our wonderful <a href="https://docs.readthedocs.io/page/team.html" target="_blank">community team</a> who helps us
+          Thanks so much to our wonderful <a href="https://docs.readthedocs.com/platform/stable/team.html"
+    target="_blank">community team</a> who helps us
           run the site.
           Read the Docs wouldn't be possible without them.
         {% endblocktrans %}

--- a/readthedocsext/theme/templates/includes/footer.html
+++ b/readthedocsext/theme/templates/includes/footer.html
@@ -36,12 +36,14 @@
           <div class="ui vertical inverted text menu">
             {% block menu_learn %}
               <h4 class="ui inverted sub header">Learn more</h4>
-              <a class="item" href="https://docs.readthedocs.io" target="_blank">Documentation</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/tutorial/index.html"
+                 href="https://docs.readthedocs.com/platform/stable/"
+                 target="_blank">Documentation</a>
+              <a class="item"
+                 href="https://docs.readthedocs.com/platform/stable/tutorial/index.html"
                  target="_blank">Getting started guide</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/config-file/"
+                 href="https://docs.readthedocs.com/platform/stable/config-file/"
                  target="_blank">Configure your project</a>
             {% endblock menu_learn %}
           </div>
@@ -61,10 +63,10 @@
                  href="https://www.ethicalads.io/advertisers/?ref=rtd"
                  target="_blank">Advertise with Us</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/privacy-policy.html"
+                 href="https://docs.readthedocs.com/platform/stable/privacy-policy.html"
                  target="_blank">Privacy Policy</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/terms-of-service.html"
+                 href="https://docs.readthedocs.com/platform/stable/terms-of-service.html"
                  target="_blank">Terms of Service</a>
             {% endblock menu_services %}
           </div>
@@ -78,10 +80,10 @@
                  href="https://about.readthedocs.com/company/"
                  target="_blank">Company</a>
               <a class="item"
-                 href="https://docs.readthedocs.io/page/team.html"
+                 href="https://docs.readthedocs.com/platform/stable/team.html"
                  target="_blank">Team</a>
               <a class="item"
-                 href="https://dev.readthedocs.io/page/contribute.html"
+                 href="https://docs.readthedocs.com/dev/latest/contribute.html"
                  target="_blank">Contributing</a>
 
               {# TODO move this out of the footer and drop this menu from this block/column  #}
@@ -110,7 +112,7 @@
             <div class="content">
               <div class="header">{% trans "Version" %}</div>
               <div class="description">
-                <a href="https://docs.readthedocs.io/page/changelog.html"
+                <a href="https://docs.readthedocs.com/platform/stable/changelog.html"
                    target="_blank">{% readthedocs_version %}</a>
               </div>
             </div>

--- a/readthedocsext/theme/templates/includes/utils/header_menus.html
+++ b/readthedocsext/theme/templates/includes/utils/header_menus.html
@@ -16,7 +16,8 @@ Submenus of the user dropdown and the mobile viewport hamburger menus.
 </a>
 
 {% if USE_ORGANIZATIONS %}
-  <a class="{% if active_item == "organizations" %}active {% endif %} computer only item" href="{% url 'organization_list' %}">
+  <a class="{% if active_item == "organizations" %}active {% endif %} computer only item"
+     href="{% url 'organization_list' %}">
     <i class="fa-duotone fa-building icon"></i>
     {% trans "Organizations" %}
   </a>
@@ -44,14 +45,15 @@ Submenus of the user dropdown and the mobile viewport hamburger menus.
   <i class="fad fa-envelope primary icon"></i>
   {% trans 'Support' %}
 </a>
-<a class="item" href="https://docs.readthedocs.io">
+<a class="item" href="https://docs.readthedocs.com/platform/stable/">
   <i class="fad fa-book primary icon"></i>
   {% trans 'Docs' %}
   <span class="description">
     <i class="fad fa-external-link icon"></i>
   </span>
 </a>
-<a class="item" href="https://docs.readthedocs.io/page/tutorial/">
+<a class="item"
+   href="https://docs.readthedocs.com/platform/stable/tutorial/">
   <i class="fad fa-rocket primary icon"></i>
   {% trans 'Getting started' %}
   <span class="description">

--- a/readthedocsext/theme/templates/organizations/settings/base.html
+++ b/readthedocsext/theme/templates/organizations/settings/base.html
@@ -11,20 +11,25 @@
     <div class="five wide computer five wide tablet sixteen wide mobile column">
 
       <div class="ui vertical pointing fluid menu">
-        <a class="item {% block organization_details_active %}{% endblock %}" href="{% url 'organization_edit' organization.slug %}">
+        <a class="item {% block organization_details_active %}{% endblock %}"
+           href="{% url 'organization_edit' organization.slug %}">
           {% trans "Details" %}
         </a>
-        <a class="item {% block organization_owners_active %}{% endblock %}" href="{% url 'organization_owners' organization.slug %}">
+        <a class="item {% block organization_owners_active %}{% endblock %}"
+           href="{% url 'organization_owners' organization.slug %}">
           {% trans "Owners" %}
         </a>
-        <a class="item {% block organization_security_log_active %}{% endblock %}" href="{% url 'organization_security_log' organization.slug %}">
+        <a class="item {% block organization_security_log_active %}{% endblock %}"
+           href="{% url 'organization_security_log' organization.slug %}">
           {% trans "Security log" %}
         </a>
         {% if USE_ORGANIZATIONS %}
-          <a class="item {% block organization_subscription_active %}{% endblock %}" href="{% url 'subscription_detail' organization.slug %}">
+          <a class="item {% block organization_subscription_active %}{% endblock %}"
+             href="{% url 'subscription_detail' organization.slug %}">
             {% trans "Subscription" %}
           </a>
-          <a class="item {% block organization_sso_active %}{% endblock %}" href="{% url 'organization_sso' organization.slug %}">
+          <a class="item {% block organization_sso_active %}{% endblock %}"
+             href="{% url 'organization_sso' organization.slug %}">
             {% trans "Authorization" %}
           </a>
         {% endif %}
@@ -38,7 +43,7 @@
             <div class="ui bulleted list">
               {% block organization_edit_sidebar_help_topics %}
               {% endblock organization_edit_sidebar_help_topics %}
-              {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/" text=_("Documentation index") is_external=True class="item" %}
+              {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/" text=_("Documentation index") is_external=True class="item" %}
             </div>
           </div>
         {% endblock organization_edit_sidebar_help_topics_container %}

--- a/readthedocsext/theme/templates/organizations/settings/saml.html
+++ b/readthedocsext/theme/templates/organizations/settings/saml.html
@@ -8,8 +8,8 @@
 {% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/guides/set-up-single-sign-on-saml.html" text=_("How to set up single sign-on with SAML") is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/set-up-single-sign-on-saml.html" text=_("How to set up single sign-on with SAML") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
 {% endblock organization_edit_sidebar_help_topics %}
 
 {% block organization_edit_content %}

--- a/readthedocsext/theme/templates/organizations/settings/security_log.html
+++ b/readthedocsext/theme/templates/organizations/settings/security_log.html
@@ -14,7 +14,7 @@
 {% endblock organization_edit_content_header %}
 
 {% block organization_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/security-log.html#organization-security-log" text=_("Organization security log") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/security-log.html#organization-security-log" text=_("Organization security log") is_external=True class="item" %}
 {% endblock organization_edit_sidebar_help_topics %}
 
 {% block organization_edit_content %}

--- a/readthedocsext/theme/templates/organizations/settings/sso_edit.html
+++ b/readthedocsext/theme/templates/organizations/settings/sso_edit.html
@@ -16,7 +16,7 @@
 {% endblock organization_edit_content_header %}
 
 {% block organization_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
 {% endblock organization_edit_sidebar_help_topics %}
 
 {% block organization_edit_content %}

--- a/readthedocsext/theme/templates/profiles/partials/token_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/token_list.html
@@ -34,7 +34,7 @@
 
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/api/v3.html#token"
+     href="https://docs.readthedocs.com/platform/stable/api/v3.html#token"
      aria-label="{% trans "Learn more about API tokens in our documentation" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/profiles/private/advertising_profile.html
+++ b/readthedocsext/theme/templates/profiles/private/advertising_profile.html
@@ -35,7 +35,7 @@
       For more details on advertising on Read the Docs
       including the privacy protections we have in place for users
       and community advertising we run on behalf of the open source community,
-      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html"
+      see <a href="https://docs.readthedocs.com/platform/stable/advertising/ethical-advertising.html"
     target="_blank">our documentation</a>.
     {% endblocktrans %}
   </p>

--- a/readthedocsext/theme/templates/profiles/private/security_log.html
+++ b/readthedocsext/theme/templates/profiles/private/security_log.html
@@ -19,7 +19,7 @@
 {% block edit_sidebar %}
   <div class="ui small info message">
     <i class="fas fa-question-circle icon"></i>
-    {% blocktrans trimmed with days_limit=days_limit docs_url="https://docs.readthedocs.io/page/security-log.html#user-security-log" %}
+    {% blocktrans trimmed with days_limit=days_limit docs_url="https://docs.readthedocs.com/platform/stable/security-log.html#user-security-log" %}
       The <a href="{{ docs_url }}"
     aria-label="Learn more about user security logs in our documentation"
     target="_blank">user security log</a> allows you to see what has happened recently in your account.

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -15,7 +15,7 @@
 {% endblock project_edit_content_header %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/addons.html" text="Addons documentation" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/addons.html" text="Addons documentation" is_external=True class="item" %}
   {% include "includes/elements/link.html" with url="https://about.readthedocs.com/blog/2024/04/enable-beta-addons/" text="Blog post: Empower your documentation with addons" is_external=True class="item" %}
   {% include "includes/elements/link.html" with url="https://blog.readthedocs.com/addons-flyout-menu-beta/" text="Blog post: Addons flyout menu beta" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/advertising.html
+++ b/readthedocsext/theme/templates/projects/advertising.html
@@ -4,10 +4,14 @@
 {% load static %}
 {% load crispy_forms_filters %}
 
-{% block title %}{% trans "Documentation advertising" %}{% endblock %}
+{% block title %}
+  {% trans "Documentation advertising" %}
+{% endblock %}
 
 {% block project-ads-active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Documentation advertising" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Documentation advertising" %}
+{% endblock %}
 
 {% block project_edit_content %}
   <p>
@@ -48,9 +52,9 @@
     {% blocktrans trimmed %}
       For more details on advertising on Read the Docs,
       including the privacy protections we have in place for users
-      and <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html#community-ads">community advertising</a>
+      and <a href="https://docs.readthedocs.com/platform/stable/advertising/ethical-advertising.html#community-ads">community advertising</a>
       we run on behalf of the open source community,
-      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html">our documentation</a>.
+      see <a href="https://docs.readthedocs.com/platform/stable/advertising/ethical-advertising.html">our documentation</a>.
     {% endblocktrans %}
   </p>
 
@@ -117,13 +121,15 @@
     </p>
 
     <p>
-      <input class="ui button primary" type="submit" value="{% trans "Update advertising preference" %}">
+      <input class="ui button primary"
+             type="submit"
+             value="{% trans "Update advertising preference" %}">
     </p>
   </form>
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/ethical-advertising.html" text="EthicalAds Documentation" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/open-source-philosophy.html" text="Read the Docs open source philosophy" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/advertising/ethical-advertising.html" text="EthicalAds Documentation" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/open-source-philosophy.html" text="Read the Docs open source philosophy" is_external=True class="item" %}
   {% include "includes/elements/link.html" with url="https://www.ethicalads.io/" text="EthicalAds website" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/automation_rule_list.html
@@ -2,10 +2,14 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Automation Rules" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Automation Rules" %}
+{% endblock %}
 
 {% block project_automation_rules_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Automation Rules" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Automation Rules" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/automation_rule_list.html" with objects=object_list %}
@@ -13,6 +17,6 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/automation-rules.html" text="Automation rules" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/automation-rules.html" text="Automation rules" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/base_dashboard.html
+++ b/readthedocsext/theme/templates/projects/base_dashboard.html
@@ -39,15 +39,15 @@
         <h2 class="ui small header">{% trans "Help topics" %}</h2>
         <div class="ui mini header">{% trans "Tutorials" %}</div>
         <div class="ui bulleted list">
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Getting started" is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Creating a project" is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/doctools.html" text="Quickstart with popular tools" is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/tutorial/index.html" text="Getting started" is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/intro/add-project.html" text="Creating a project" is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/intro/doctools.html" text="Quickstart with popular tools" is_external=True class="item" %}
         </div>
 
         <div class="ui mini header">{% trans "Reference" %}</div>
         <div class="ui bulleted list">
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/index.html" text="Configuration file reference" is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/build-customization.html" text="Build process customization" is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/config-file/index.html" text="Configuration file reference" is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/build-customization.html" text="Build process customization" is_external=True class="item" %}
         </div>
       </div>
     </div>

--- a/readthedocsext/theme/templates/projects/domain_list.html
+++ b/readthedocsext/theme/templates/projects/domain_list.html
@@ -30,7 +30,7 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/custom-domains.html" text="How to manage custom domains" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/subprojects.html" text="Subprojects: host multiple projects on a single domain" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html#canonical-urls" text="Canonical URLs and domains" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/custom-domains.html" text="How to manage custom domains" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/subprojects.html" text="Subprojects: host multiple projects on a single domain" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html#canonical-urls" text="Canonical URLs and domains" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/edit_base.html
+++ b/readthedocsext/theme/templates/projects/edit_base.html
@@ -93,7 +93,7 @@
               <div class="ui bulleted list">
                 {% block project_edit_sidebar_help_topics %}
                 {% endblock project_edit_sidebar_help_topics %}
-                {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/" text=_("Documentation index") is_external=True class="item" %}
+                {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/" text=_("Documentation index") is_external=True class="item" %}
               </div>
             {% endblock project_edit_sidebar_help_topics_content %}
           </div>

--- a/readthedocsext/theme/templates/projects/environmentvariable_list.html
+++ b/readthedocsext/theme/templates/projects/environmentvariable_list.html
@@ -18,7 +18,7 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/environment-variables.html" text="How to use custom environment variables" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/environment-variables.html" text="Understanding environment variables" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/reference/environment-variables.html" text="Predefined environment variables" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/environment-variables.html" text="How to use custom environment variables" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/environment-variables.html" text="Understanding environment variables" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/reference/environment-variables.html" text="Predefined environment variables" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/import_base.html
+++ b/readthedocsext/theme/templates/projects/import_base.html
@@ -42,9 +42,9 @@
                 <h2 class="ui small header">{% trans "Help topics" %}</h2>
                 <div class="ui list">
                   {% block project_add_sidebar_help_topics %}
-                    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Connecting a repository" is_external=True class="item" %}
-                    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Read the Docs tutorial" is_external=True class="item" %}
-                    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/examples.html" text="Example projects" is_external=True class="item" %}
+                    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/intro/add-project.html" text="Connecting a repository" is_external=True class="item" %}
+                    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/tutorial/index.html" text="Read the Docs tutorial" is_external=True class="item" %}
+                    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/examples.html" text="Example projects" is_external=True class="item" %}
                   {% endblock project_add_sidebar_help_topics %}
                 </div>
               </div>

--- a/readthedocsext/theme/templates/projects/import_config.html
+++ b/readthedocsext/theme/templates/projects/import_config.html
@@ -32,7 +32,7 @@
         <div class="item" data-tab="others">{% trans "Others" %}</div>
         {# The `actionable` class here prevents the select from selecting the text #}
         <a class="actionable item"
-           href="https://docs.readthedocs.io/page/config-file/index.html#getting-started-with-a-template"
+           href="https://docs.readthedocs.com/platform/stable/config-file/index.html#getting-started-with-a-template"
            target="_blank">{% trans "See more examples" %}</a>
       </div>
     </div>
@@ -51,7 +51,7 @@
       <code class="highlight">
         <pre id="project-create-sample-sphinx">
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -68,7 +68,7 @@ sphinx:
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# See https://docs.readthedocs.com/platform/stable/guides/reproducible-builds.html
 # python:
 #    install:
 #    - requirements: docs/requirements.txt
@@ -90,7 +90,7 @@ sphinx:
       <code class="highlight">
         <pre id="project-create-sample-mkdocs">
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -107,7 +107,7 @@ mkdocs:
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# See https://docs.readthedocs.com/platform/stable/guides/reproducible-builds.html
 # python:
 #    install:
 #    - requirements: docs/requirements.txt
@@ -129,7 +129,7 @@ mkdocs:
       <code class="highlight">
         <pre id="project-create-sample-docusaurus">
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -166,7 +166,7 @@ build:
       <code class="highlight">
         <pre id="project-create-sample-pelican">
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -200,7 +200,7 @@ build:
       <code class="highlight">
         <pre id="project-create-sample-jekyll">
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -235,7 +235,7 @@ build:
       <code class="highlight">
         <pre id="project-create-sample-others">
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -270,7 +270,7 @@ build:
 {% endblock project_add_content_form %}
 
 {% block project_add_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/index.html" text="Configuration file tutorial" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/v2.html" text="Configuration file reference" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/setup/git-repo-manual.html" text="Manually configuring a Git repository" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/config-file/index.html" text="Configuration file tutorial" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/config-file/v2.html" text="Configuration file reference" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/setup/git-repo-manual.html" text="Manually configuring a Git repository" is_external=True class="item" %}
 {% endblock project_add_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/import_form.html
+++ b/readthedocsext/theme/templates/projects/import_form.html
@@ -10,7 +10,8 @@
 {% endblock project_add_subheader %}
 
 {% block project_add_sidebar_content %}
-  <div class="ui fluid secondary pointing vertical menu" data-bind="css: {vertical: device.computer()}">
+  <div class="ui fluid secondary pointing vertical menu"
+       data-bind="css: {vertical: device.computer()}">
     <a class="active item" data-tab="automatic">
       <i class="fa-duotone fa-magic icon"></i>
       {% trans "Configure automatically" %}
@@ -22,7 +23,9 @@
   </div>
 {% endblock project_add_sidebar_content %}
 
-{% block project_add_data_bind %}data-bind="using: ProjectCreateView()"{% endblock %}
+{% block project_add_data_bind %}
+  data-bind="using: ProjectCreateView()"
+{% endblock %}
 
 {% block project_add_content_form %}
   {% block project_add_automatic_tab %}
@@ -30,7 +33,7 @@
 
       {{ form_automatic | as_crispy_errors }}
 
-      <div class="ui {% if form_automatic.is_disabled %} disabled {% endif %} basic segment">
+      <div class="ui {% if form_automatic.is_disabled %}disabled{% endif %} basic segment">
         {% include "projects/partials/project_create_automatic.html" %}
       </div>
     </div>
@@ -41,7 +44,7 @@
 
       {{ form_manual | as_crispy_errors }}
 
-      <div class="ui {% if form_manual.is_disabled %} disabled {% endif %} basic segment">
+      <div class="ui {% if form_manual.is_disabled %}disabled{% endif %} basic segment">
         <div class="ui small message">
           <div class="header">
             <i class="fa-solid fa-triangle-exclamation icon"></i>
@@ -61,9 +64,9 @@
           </p>
         </div>
         <div class="ui right aligned basic segment">
-          <a class="ui basic button" href="https://docs.readthedocs.io/page/intro/import-guide.html" target="_blank">
-            {% trans "Learn more" %}
-          </a>
+          <a class="ui basic button"
+             href="https://docs.readthedocs.com/platform/stable/intro/add-project.html"
+             target="_blank">{% trans "Learn more" %}</a>
           <a class="ui primary button" href="{% url 'projects_import_manual' %}">
             {% trans "Continue" %}
           </a>

--- a/readthedocsext/theme/templates/projects/integration_list.html
+++ b/readthedocsext/theme/templates/projects/integration_list.html
@@ -18,6 +18,6 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/connecting-git-account.html" text="How to connect your Read the Docs account to your Git provider" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/guides/setup/git-repo-automatic.html" text="How to automatically configure a Git repository" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/connecting-git-account.html" text="How to connect your Read the Docs account to your Git provider" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/setup/git-repo-manual.html" text="How to automatically configure a Git repository" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/integration_webhook_detail.html
+++ b/readthedocsext/theme/templates/projects/integration_webhook_detail.html
@@ -4,7 +4,9 @@
 
 {% block project_edit_content_subheader %}
   <div class="ui breadcrumb">
-    <div class="active section">{{ integration.get_integration_type_display }}</div>
+    <div class="active section">
+      {{ integration.get_integration_type_display }}
+    </div>
   </div>
 {% endblock project_edit_content_subheader %}
 
@@ -117,7 +119,8 @@
     <p>
       {% blocktrans trimmed %}
         For more information on manually configuring a webhook, refer to
-        <a href="https://docs.readthedocs.io/page/webhooks.html" target="_blank">our webhook documentation.</a>
+        <a href="https://docs.readthedocs.com/platform/stable/reference/git-integration.html"
+           target="_blank">our webhook documentation.</a>
       {% endblocktrans %}
     </p>
   {% endif %}

--- a/readthedocsext/theme/templates/projects/notification_list.html
+++ b/readthedocsext/theme/templates/projects/notification_list.html
@@ -3,15 +3,19 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Notifications" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Notifications" %}
+{% endblock %}
 
 {% block project_notifications_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Notifications" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Notifications" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/notification_email_list.html" with objects=emails %}
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/build-notifications.html" text="How to set up build notifications" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/build/email-notifications.html" text="How to set up build notifications" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/onboard_detail.html
+++ b/readthedocsext/theme/templates/projects/onboard_detail.html
@@ -38,7 +38,8 @@
                 Your documentation has been built.
                 Ensure your documentation is kept up to date with every commit to
                 your repository, by
-                <a href="https://docs.readthedocs.io/page/webhooks.html" target="_blank">setting up a webhook</a>.
+                <a href="https://docs.readthedocs.com/platform/stable/reference/git-integration.html"
+                   target="_blank">setting up a webhook</a>.
               {% endblocktrans %}
             </p>
 
@@ -58,7 +59,8 @@
                 There was a problem building your documentation,
                 you can see what went wrong in the build output.
                 If you need more help, check out some of the
-                <a href="https://docs.readthedocs.io/page/faq.html" target="_blank">problems frequently encountered</a>
+                <a href="https://docs.readthedocs.com/platform/stable/faq.html"
+                   target="_blank">problems frequently encountered</a>
                 during builds.
               {% endblocktrans %}
             </p>

--- a/readthedocsext/theme/templates/projects/onboard_import.html
+++ b/readthedocsext/theme/templates/projects/onboard_import.html
@@ -8,7 +8,7 @@
     ?
   </h2>
 
-  {% with getting_started_url="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" %}
+  {% with getting_started_url="https://docs.readthedocs.com/platform/stable/intro/sphinx.html" %}
     <form class="ui form" method="get" action="{% url "projects_import" %}">
       <p>
         {% blocktrans trimmed %}

--- a/readthedocsext/theme/templates/projects/partials/announcements/example-projects.html
+++ b/readthedocsext/theme/templates/projects/partials/announcements/example-projects.html
@@ -1,6 +1,6 @@
 {% load blocktrans trans from i18n %}
 
-{% with "https://docs.readthedocs.io/page/examples.html" as url %}
+{% with "https://docs.readthedocs.com/platform/stable/examples.html" as url %}
   <div data-bind="using: new ProjectAnnouncementView('example-projects')">
     <div class="ui fluid card ko hidden" data-bind="css: { hidden: closed }">
       <div class="content">

--- a/readthedocsext/theme/templates/projects/partials/announcements/pull-request-previews.html
+++ b/readthedocsext/theme/templates/projects/partials/announcements/pull-request-previews.html
@@ -1,6 +1,6 @@
 {% load blocktrans trans from i18n %}
 
-{% with "https://docs.readthedocs.io/page/pull-requests.html" as url %}
+{% with "https://docs.readthedocs.com/platform/stable/pull-requests.html" as url %}
   <div data-bind="using: new ProjectAnnouncementView('pull-requests')">
     <div class="ui fluid card ko hidden" data-bind="css: { hidden: closed }">
       <div class="content">

--- a/readthedocsext/theme/templates/projects/partials/announcements/security-logs.html
+++ b/readthedocsext/theme/templates/projects/partials/announcements/security-logs.html
@@ -1,6 +1,6 @@
 {% load blocktrans trans from i18n %}
 
-{% with "https://docs.readthedocs.io/page/security-log.html" as url %}
+{% with "https://docs.readthedocs.com/platform/stable/security-log.html" as url %}
   <div data-bind="using: new ProjectAnnouncementView('security-logs')">
     <div class="ui fluid card ko hidden" data-bind="css: { hidden: closed }">
       <div class="content">

--- a/readthedocsext/theme/templates/projects/partials/announcements/traffic-analytics.html
+++ b/readthedocsext/theme/templates/projects/partials/announcements/traffic-analytics.html
@@ -1,6 +1,6 @@
 {% load blocktrans trans from i18n %}
 
-{% with "https://docs.readthedocs.io/page/analytics.html" as url %}
+{% with "https://docs.readthedocs.com/platform/stable/traffic-analytics.html" as url %}
   <div data-bind="using: new ProjectAnnouncementView('traffic-analytics')">
     <div class="ui fluid card ko hidden" data-bind="css: { hidden: closed }">
       <div class="content">

--- a/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/automation_rule_list.html
@@ -33,7 +33,7 @@
 {% block list_placeholder_text %}
   <a class="ui button"
      target="_blank"
-     href="https://docs.readthedocs.io/page/automation-rules.html">{% trans "Learn more" %}</a>
+     href="https://docs.readthedocs.com/platform/stable/automation-rules.html">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block list_item_right_buttons %}

--- a/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/domain_list.html
@@ -19,7 +19,7 @@
     No domains are currently configured.
   {% endblocktrans %}
   <div class="sub header">
-    {% blocktrans trimmed with docs_url='https://docs.readthedocs.io/page/custom_domains.html' %}
+    {% blocktrans trimmed with docs_url='https://docs.readthedocs.com/platform/stable/custom-domains.html' %}
       Configuring a custom domain allows you to serve your documentation from a
       domain other than "{{ default_domain }}".
     {% endblocktrans %}
@@ -27,7 +27,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/custom-domains.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/custom-domains.html"
      target="_blank"
      aria-label="{% trans "Learn more about custom domains in our documentation" %}">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/environment_variable_list.html
@@ -28,7 +28,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/environment-variables.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/environment-variables.html"
      aria-label="{% trans "Learn more about user-defined environment variables in our documentation" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/integration_list.html
@@ -28,7 +28,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/setup/git-repo-manual.html"
      target="_blank"
      aria-label="{% trans "Learn more about connecting your Git provider in our documentation" %}">
     {% trans "Learn more" %}

--- a/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/keys_list.html
@@ -35,7 +35,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/importing-private-repositories.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/creating-project-private-repository.html"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/notification_email_list.html
@@ -28,7 +28,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/build-notifications.html#email-notifications"
+     href="https://docs.readthedocs.com/platform/stable/guides/build/email-notifications.html"
      aria-label="{% trans "Learn more about email notifications in our documentation" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -24,7 +24,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/redirects.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/redirects.html"
      target="_blank"
      aria-label="{% trans "Learn more about custom redirects in our documentation" %}">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/search_query_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/search_query_list.html
@@ -28,7 +28,7 @@
 
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/search-analytics.html"
+     href="https://docs.readthedocs.com/platform/stable/search-analytics.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/subproject_list.html
@@ -28,7 +28,7 @@
 
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/en/stable/guides/subprojects.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/subprojects.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/temporary_access_list.html
@@ -27,7 +27,7 @@
 
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/commercial/sharing.html"
+     href="https://docs.readthedocs.com/platform/stable/commercial/sharing.html"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/traffic_list.html
@@ -35,7 +35,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/en/stable/traffic-analytics.html"
+     href="https://docs.readthedocs.com/platform/stable/traffic-analytics.html"
      aria-label="{% trans "Learn more about traffic analytics in our documentation" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/translation_list.html
@@ -27,7 +27,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/localization.html"
+     href="https://docs.readthedocs.com/platform/stable/localization.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/webhook_list.html
@@ -24,7 +24,7 @@
 
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/page/guides/build-notifications.html#build-status-webhooks"
+     href="https://docs.readthedocs.com/platform/stable/guides/build/webhooks.html"
      aria-label="{% trans "Learn more about webhooks in our documentation" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -303,7 +303,7 @@
                   </p>
                   <p class="ui red text" data-bind="visible: !admin">
                     <a class="ui red mini basic button"
-                       href="https://docs.readthedocs.io/page/intro/import-guide.html#manually-import-your-docs"
+                       href="https://docs.readthedocs.com/platform/stable/intro/add-project.html#manually-import-your-docs"
                        target="_blank">{% trans "Learn how to manually configure this repository" %}</a>
                   </p>
                 </div>

--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -24,7 +24,7 @@
   {% trans "You don't have any projects configured yet" %}
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
-  <a href="https://docs.readthedocs.io/page/tutorial/"
+  <a href="https://docs.readthedocs.com/platform/stable/tutorial/"
      target="_blank"
      class="ui primary button">{% trans "Learn how to get started" %}</a>
 {% endblock list_placeholder_text_empty %}

--- a/readthedocsext/theme/templates/projects/projectrelationship_list.html
+++ b/readthedocsext/theme/templates/projects/projectrelationship_list.html
@@ -2,19 +2,21 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Subprojects" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Subprojects" %}
+{% endblock %}
 
 {% block project_subprojects_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Subprojects" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Subprojects" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% if superproject %}
     <div class="ui icon message">
       <i class="fa-duotone fa-circle-exclamation icon"></i>
       <div class="content">
-        <div class="header">
-          {% trans "Nested subprojects are not supported" %}
-        </div>
+        <div class="header">{% trans "Nested subprojects are not supported" %}</div>
         <p>
           {% blocktrans trimmed with project=superproject.name %}
             This project is already configured as a subproject of {{ project }}.
@@ -36,5 +38,5 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/subprojects.html" text="Subprojects: host multiple projects on a single domain" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/subprojects.html" text="Subprojects: host multiple projects on a single domain" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/pull_requests_form.html
+++ b/readthedocsext/theme/templates/projects/pull_requests_form.html
@@ -4,10 +4,14 @@
 {% load static %}
 {% load crispy_forms_filters %}
 
-{% block title %}{% trans "Pull request builds" %}{% endblock %}
+{% block title %}
+  {% trans "Pull request builds" %}
+{% endblock %}
 
 {% block project_pull_requests_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Pull request builds" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Pull request builds" %}
+{% endblock %}
 
 {% block project_edit_content %}
   <p>
@@ -20,11 +24,12 @@
     {% csrf_token %}
     {{ form | crispy }}
 
-    <input class="ui {% if form.errors and form.is_disabled %}disabled{% endif %} primary button" type="submit"
+    <input class="ui {% if form.errors and form.is_disabled %}disabled{% endif %} primary button"
+           type="submit"
            value="{% trans " Update" %}">
   </form>
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/pull-requests.html" text="Pull request builds" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/pull-requests.html" text="Pull request builds" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/redirect_list.html
@@ -3,17 +3,21 @@
 {% load i18n %}
 {% load ext_theme_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Redirects" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Redirects" %}
+{% endblock %}
 
 {% block project_redirects_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Redirects" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Redirects" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/redirect_list.html" with objects=redirects %}
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/redirects.html" text="How to use custom URL redirects in documentation projects" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/user-defined-redirects.html" text="Custom and built-in redirects on Read the Docs" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/best-practice/links.html" text="Best practices for linking to your documentation" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/redirects.html" text="How to use custom URL redirects in documentation projects" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/user-defined-redirects.html" text="Custom and built-in redirects on Read the Docs" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/best-practice/links.html" text="Best practices for linking to your documentation" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/search_analytics.html
+++ b/readthedocsext/theme/templates/projects/search_analytics.html
@@ -69,6 +69,6 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/search-analytics.html" text="How to use search analytics" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html" text="How to do search engine optimization (SEO) for documentation projects" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/search-analytics.html" text="How to use search analytics" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html" text="How to do search engine optimization (SEO) for documentation projects" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/settings_advanced_form.html
+++ b/readthedocsext/theme/templates/projects/settings_advanced_form.html
@@ -3,8 +3,12 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Advanced Settings" %}{% endblock %}
-{% block project_edit_content_header %}{% trans "Advanced Settings" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Advanced Settings" %}
+{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Advanced Settings" %}
+{% endblock %}
 {% block project_advanced_active %}active{% endblock %}
 
 {% block project_edit_content %}
@@ -16,7 +20,7 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/setup/monorepo.html" text="How to use a .readthedocs.yaml file in a sub-folder" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/single-version.html" text="Single version documentation" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/setup/monorepo.html" text="How to use a .readthedocs.yaml file in a sub-folder" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/build-default-versions.html" text="Single version documentation" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/settings_basics_form.html
+++ b/readthedocsext/theme/templates/projects/settings_basics_form.html
@@ -71,16 +71,16 @@
 {% block project_edit_sidebar_help_topics_content %}
   <div class="ui mini header">{% trans "Tutorials" %}</div>
   <div class="ui bulleted list">
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Getting started" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Importing your documentation" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/doctools.html" text="Quickstart with popular tools" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/tutorial/index.html" text="Getting started" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/intro/add-project.html" text="Importing your documentation" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/intro/doctools.html" text="Quickstart with popular tools" is_external=True class="item" %}
   </div>
   <div class="ui mini header">{% trans "Resources" %}</div>
   <div class="ui bulleted list">
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/v2.html" text="Configuration file" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/pull-requests.html" text="How to configure pull request builds" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/setup/monorepo.html" text="How to use a .readthedocs.yaml file in a sub-folder" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/versioning-schemes.html" text="URL versioning schemes" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/config-file/v2.html" text="Configuration file" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/pull-requests.html" text="How to configure pull request builds" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/setup/monorepo.html" text="How to use a .readthedocs.yaml file in a sub-folder" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/versioning-schemes.html" text="URL versioning schemes" is_external=True class="item" %}
   </div>
 {% endblock project_edit_sidebar_help_topics_content %}

--- a/readthedocsext/theme/templates/projects/traffic_analytics.html
+++ b/readthedocsext/theme/templates/projects/traffic_analytics.html
@@ -77,6 +77,6 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/analytics.html" text="How to use traffic analytics" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html" text="How to do search engine optimization (SEO) for documentation projects" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/traffic-analytics.html" text="How to use traffic analytics" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html" text="How to do search engine optimization (SEO) for documentation projects" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/translation_list.html
+++ b/readthedocsext/theme/templates/projects/translation_list.html
@@ -3,10 +3,14 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Translations" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Translations" %}
+{% endblock %}
 
 {% block project_translations_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Translations" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Translations" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% if not project.supports_translations %}
@@ -14,44 +18,40 @@
     <div class="ui icon message">
       <i class="fa-duotone fa-circle-exclamation icon"></i>
       <div class="content">
-        <div class="header">
-          {% trans "Translations are not supported" %}
-        </div>
+        <div class="header">{% trans "Translations are not supported" %}</div>
         <p>
           {% blocktrans trimmed with project_settings_url=project_settings_url %}
             This project is <a href="{{ project_settings_url }}">configured</a> with a versioning scheme that doesn't support translations.
           {% endblocktrans %}
         </p>
       </div>
-  {% elif project.main_language_project %}
-    <div class="ui icon message">
-      <i class="fa-duotone fa-diagram-nested icon"></i>
-      <div class="content">
-        <div class="header">
-          {% trans "Nested translations are not supported" %}
-        </div>
-        <p>
-          {% blocktrans trimmed with language=project.get_language_display  main_project=project.main_language_project.name %}
-            This project is already configured as the {{ language }} translation of
-            "{{ main_project }}".
-          {% endblocktrans %}
-        </p>
-
-        <p>
-          <a href="{% url 'projects_translations' project_slug=project.main_language_project.slug %}">
-            {% blocktrans trimmed with main_project=project.main_language_project.name %}
-              View all translations of "{{ main_project }}".
+    {% elif project.main_language_project %}
+      <div class="ui icon message">
+        <i class="fa-duotone fa-diagram-nested icon"></i>
+        <div class="content">
+          <div class="header">{% trans "Nested translations are not supported" %}</div>
+          <p>
+            {% blocktrans trimmed with language=project.get_language_display  main_project=project.main_language_project.name %}
+              This project is already configured as the {{ language }} translation of
+              "{{ main_project }}".
             {% endblocktrans %}
-          </a>
-        </p>
-      </div>
-    </div>
-  {% else %}
-    {% include "projects/partials/edit/translation_list.html" with objects=lang_projects %}
-  {% endif %}
-{% endblock %}
+          </p>
 
-{% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/localization.html" text="Localization of documentation" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/manage-translations-sphinx.html" text="How to manage translations for Sphinx projects" is_external=True class="item" %}
-{% endblock project_edit_sidebar_help_topics %}
+          <p>
+            <a href="{% url 'projects_translations' project_slug=project.main_language_project.slug %}">
+              {% blocktrans trimmed with main_project=project.main_language_project.name %}
+                View all translations of "{{ main_project }}".
+              {% endblocktrans %}
+            </a>
+          </p>
+        </div>
+      </div>
+    {% else %}
+      {% include "projects/partials/edit/translation_list.html" with objects=lang_projects %}
+    {% endif %}
+  {% endblock %}
+
+  {% block project_edit_sidebar_help_topics %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/localization.html" text="Localization of documentation" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/manage-translations-sphinx.html" text="How to manage translations for Sphinx projects" is_external=True class="item" %}
+  {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/user_list.html
+++ b/readthedocsext/theme/templates/projects/user_list.html
@@ -3,10 +3,14 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Maintainers" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Maintainers" %}
+{% endblock %}
 
 {% block project_users_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Maintainers" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Maintainers" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/user_list.html" with objects=users %}
@@ -33,9 +37,7 @@
     {% if invitations.exists %}
       <h2 class="ui small header">
         {% trans "Pending invitations" %}
-        <span class="ui circular small label">
-          {{ invitations.count }}
-        </span>
+        <span class="ui circular small label">{{ invitations.count }}</span>
       </h2>
       {% include "invitations/partials/invitation_list.html" with objects=invitations skip_pagination=True %}
     {% endif %}
@@ -43,5 +45,5 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/glossary.html#term-maintainer" text="What is a maintainer?" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/glossary.html#term-maintainer" text="What is a maintainer?" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/version_form.html
+++ b/readthedocsext/theme/templates/projects/version_form.html
@@ -128,7 +128,7 @@
                       {% endblocktrans %}
                     </p>
 
-                    <a href="https://docs.readthedocs.io/en/stable/versions.html"
+                    <a href="https://docs.readthedocs.com/platform/stable/versions.html"
                        class="ui primary button"
                        target="_blank">{% trans "Learn more" %}</a>
                   </div>
@@ -159,11 +159,11 @@
       <div class="ui basic segment">
         <h2 class="ui small header">{% trans "Help topics" %}</h2>
         <div class="ui bulleted list">
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/versions.html" text=_("Versions") is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/versions.html#version-states" text=_("Version states") is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/versions.html#privacy-levels" text=_("Privacy levels") is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text=_("Version automation rules") is_external=True class="item" %}
-          {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/" text=_("Documentation index") is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/versions.html" text=_("Versions") is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/versions.html#version-states" text=_("Version states") is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/versions.html#privacy-levels" text=_("Privacy levels") is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/automation-rules.html" text=_("Version automation rules") is_external=True class="item" %}
+          {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/" text=_("Documentation index") is_external=True class="item" %}
         </div>
       </div>
     </div>

--- a/readthedocsext/theme/templates/projects/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/webhook_list.html
@@ -3,15 +3,19 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Webhooks" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Webhooks" %}
+{% endblock %}
 
 {% block project_webhooks_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Webhooks" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Webhooks" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/webhook_list.html" with objects=object_list %}
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/build-notifications.html" text="How to setup build notifications and webhooks" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/build/webhooks.html" text="How to setup outgoing webhooks" is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
+++ b/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
@@ -38,7 +38,7 @@
 {% endblock list_placeholder_header %}
 {% block list_placeholder_text %}
   <a class="ui button"
-     href="https://docs.readthedocs.io/en/stable/guides/connecting-git-account.html"
+     href="https://docs.readthedocs.com/platform/stable/guides/connecting-git-account.html"
      aria-label="{% trans "Learn more about this feature in our documentation pages" %}"
      target="_blank">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text %}

--- a/readthedocsext/theme/templates/support/index.html
+++ b/readthedocsext/theme/templates/support/index.html
@@ -32,7 +32,8 @@
       </p>
 
       <p>
-        You might also find the answers you are looking for in our <a href="https://docs.readthedocs.io/page/guides/" target="_blank">documentation guides</a>.
+        You might also find the answers you are looking for in our <a href="https://docs.readthedocs.com/platform/stable/guides/"
+    target="_blank">documentation guides</a>.
         These provide step-by-step solutions to common user requirements.
       </p>
 
@@ -41,7 +42,7 @@
       <p>
         If you have an issue with the actual functioning of the site,
         you can file bug reports on our <a href="https://github.com/readthedocs/readthedocs.org/issues">GitHub issue tracker</a>.
-        You can also <a href="https://docs.readthedocs.io/page/contribute.html"
+        You can also <a href="https://docs.readthedocs.com/platform/stable/contribute.html"
     target="_blank">contribute</a> to Read the Docs,
         as the code is open source.
       </p>

--- a/readthedocsext/theme/templates/support/success.html
+++ b/readthedocsext/theme/templates/support/success.html
@@ -21,7 +21,7 @@
   </div>
 
   <p>
-    {% blocktrans trimmed with url="https://docs.readthedocs.io/en/latest/index.html#step-by-step-guides" %}
+    {% blocktrans trimmed with url="https://docs.readthedocs.com/platform/stable/index.html#step-by-step-guides" %}
       While you are waiting for a response,
       you might want to browse <a href="{{ url }}" target="_blank">our guides</a>,
       which provide step-by-step solutions to common support questions.


### PR DESCRIPTION
## Summary

- Migrate all `docs.readthedocs.io` URLs to `docs.readthedocs.com/platform/stable/`
- Migrate `dev.readthedocs.io` URLs to `docs.readthedocs.com/dev/latest/`
- Fix broken paths from renamed/moved doc pages (see commit message for full list)

## Test plan

- [ ] Spot-check links in help sidebars resolve correctly
- [ ] Check placeholder "Learn more" buttons in empty list states

🤖 Generated with [Claude Code](https://claude.ai/code)

Made by AI.