### PR TITLE
Add descriptive subheaders to settings pages

### DIFF
--- a/readthedocsext/theme/templates/organizations/settings/organization_edit.html
+++ b/readthedocsext/theme/templates/organizations/settings/organization_edit.html
@@ -13,6 +13,12 @@
 {% block organization_edit_content_header %}
   {% trans "Details" %}
 {% endblock organization_edit_content_header %}
+{% block organization_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage your organization's name, description, and basic settings.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/commercial/organizations.html" text=_("Learn more") is_external=True %}
+{% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_content %}
   <form class="ui form"

--- a/readthedocsext/theme/templates/organizations/settings/owners_edit.html
+++ b/readthedocsext/theme/templates/organizations/settings/owners_edit.html
@@ -2,10 +2,20 @@
 
 {% load i18n %}
 
-{% block title %}{{ organization.name }} - {% trans "Owners" %}{% endblock %}
+{% block title %}
+  {{ organization.name }} - {% trans "Owners" %}
+{% endblock %}
 
 {% block organization_owners_active %}active{% endblock %}
-{% block organization_edit_content_header %}{% trans "Owners" %}{% endblock %}
+{% block organization_edit_content_header %}
+  {% trans "Owners" %}
+{% endblock %}
+{% block organization_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage the users who have full administrative access to this organization.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/commercial/organizations.html" text=_("Learn more") is_external=True %}
+{% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_content %}
   {% include "organizations/partials/owners_list.html" with objects=object_list %}
@@ -33,9 +43,7 @@
     {% if invitations.exists %}
       <h2 class="ui small header">
         {% trans "Pending invitations" %}
-        <span class="ui circular small label">
-          {{ invitations.count }}
-        </span>
+        <span class="ui circular small label">{{ invitations.count }}</span>
       </h2>
       {% include "invitations/partials/invitation_list.html" with objects=invitations skip_pagination=True %}
     {% endif %}

--- a/readthedocsext/theme/templates/organizations/settings/security_log.html
+++ b/readthedocsext/theme/templates/organizations/settings/security_log.html
@@ -12,6 +12,12 @@
 {% block organization_edit_content_header %}
   {% trans "Security log" %}
 {% endblock organization_edit_content_header %}
+{% block organization_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Review security-related events and actions taken within your organization.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/security-log.html" text=_("Learn more") is_external=True %}
+{% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_sidebar_help_topics %}
   {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/security-log.html#organization-security-log" text=_("Organization security log") is_external=True class="item" %}

--- a/readthedocsext/theme/templates/organizations/settings/sso_edit.html
+++ b/readthedocsext/theme/templates/organizations/settings/sso_edit.html
@@ -14,18 +14,18 @@
 {% block organization_edit_content_header %}
   {% trans "Authorization" %}
 {% endblock organization_edit_content_header %}
+{% block organization_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Change how users authenticate in your organization and manage access to projects and documentation.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/commercial/single-sign-on.html" text=_("Learn more") is_external=True %}
+{% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_sidebar_help_topics %}
   {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
 {% endblock organization_edit_sidebar_help_topics %}
 
 {% block organization_edit_content %}
-  <p>
-    {% blocktrans trimmed %}
-      Change how users authenticate in your organization and reuse permissions from another service to control access to your projects and documentation.
-    {% endblocktrans %}
-  </p>
-
   {% if organization.ssointegration %}
     <div class="ui message">
       <div class="header">{% trans "Invite users into your organization" %}</div>

--- a/readthedocsext/theme/templates/organizations/settings/subscription_detail.html
+++ b/readthedocsext/theme/templates/organizations/settings/subscription_detail.html
@@ -6,10 +6,20 @@
 {% load static %}
 {% load humanize %}
 
-{% block title %}{{ organization.name }} - {% trans "Subscription" %}{% endblock %}
+{% block title %}
+  {{ organization.name }} - {% trans "Subscription" %}
+{% endblock %}
 
 {% block organization_subscription_active %}active{% endblock %}
-{% block organization_edit_content_header %}{% trans "Subscription" %}{% endblock %}
+{% block organization_edit_content_header %}
+  {% trans "Subscription" %}
+{% endblock %}
+{% block organization_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage your organization's subscription plan and billing.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://about.readthedocs.com/pricing/" text=_("Learn more") is_external=True %}
+{% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_sidebar_help_topics %}
   {% include "includes/elements/link.html" with url="https://about.readthedocs.com/pricing/" text=_("Pricing plans") is_external=True class="item" %}
@@ -24,35 +34,25 @@
             {{ stripe_subscription.get_status_display }}
           </span>
         </div>
-        <div class="header">
-          {{ main_product.stripe_price.product.name }}
-        </div>
-        <div class="meta">
-          {{ main_product.stripe_price.human_readable_price }}
-        </div>
+        <div class="header">{{ main_product.stripe_price.product.name }}</div>
+        <div class="meta">{{ main_product.stripe_price.human_readable_price }}</div>
         <div class="description">
           <div class="ui list">
 
             {% if extra_products %}
               <div class="item">
                 <div class="content">
-                  <div class="header">
-                    {% trans "Extra products:" %}
-                  </div>
+                  <div class="header">{% trans "Extra products:" %}</div>
                   <div class="description">
                     <div class="ui list">
                       {% for extra_product in extra_products %}
                         <div class="item">
                           <div class="content">
-                            <div class="header">
-                              {{ extra_product.stripe_price.product.name }}
-                            </div>
+                            <div class="header">{{ extra_product.stripe_price.product.name }}</div>
                             <div class="description">
                               {{ extra_product.stripe_price.human_readable_price }}
                               {% if extra_product.quantity > 1 %}
-                                <span>
-                                  (x{{ extra_product.quantity }})
-                                </span>
+                                <span>(x{{ extra_product.quantity }})</span>
                               {% endif %}
                             </div>
                           </div>
@@ -67,15 +67,11 @@
             {% if features %}
               <div class="item">
                 <div class="content">
-                  <div class="header">
-                    {% trans "Features:" %}
-                  </div>
+                  <div class="header">{% trans "Features:" %}</div>
                   <div class="description">
                     <div class="ui list">
                       {% for feature in features %}
-                        <div class="item">
-                          {{ feature.get_description }}
-                        </div>
+                        <div class="item">{{ feature.get_description }}</div>
                       {% endfor %}
                     </div>
                   </div>
@@ -86,9 +82,7 @@
             {% if stripe_subscription.start_date %}
               <div class="item">
                 <div class="content">
-                  <div class="header">
-                    {% trans "Started:" %}
-                  </div>
+                  <div class="header">{% trans "Started:" %}</div>
                   <div class="description">
                     {# Translators: this is the subscription start date, used here as "4 days ago" or "5 months ago" #}
                     {% blocktrans with time_since_signup=stripe_subscription.start_date|timesince trimmed %}
@@ -101,9 +95,7 @@
             {% if stripe_subscription.trial_end or subscription_end_date %}
               <div class="item">
                 <div class="content">
-                  <div class="header">
-                    {% trans "Ends:" %}
-                  </div>
+                  <div class="header">{% trans "Ends:" %}</div>
                   <div class="description">
                     {% if stripe_subscription.status == 'trialing' and stripe_subscription.trial_end %}
                       {% blocktrans trimmed with date_end=stripe_subscription.trial_end|date:"SHORT_DATE_FORMAT" %}
@@ -132,7 +124,9 @@
       </div>
     {% endif %}
 
-    <form class="ui form" method="post" action="{% url "stripe_customer_portal" organization.slug %}">
+    <form class="ui form"
+          method="post"
+          action="{% url "stripe_customer_portal" organization.slug %}">
       {% csrf_token %}
       <button class="ui primary button">
         {% if stripe_subscription.status == 'trialing' %}
@@ -163,7 +157,9 @@
     <form class="ui form" action="" method="post">
       {% csrf_token %}
       {{ form|crispy }}
-      <input class="ui primary button" type="submit" value="{% trans "Start subscription" %}" />
+      <input class="ui primary button"
+             type="submit"
+             value="{% trans "Start subscription" %}" />
     </form>
   {% endif %}
 {% endblock %}

--- a/readthedocsext/theme/templates/profiles/private/token_list.html
+++ b/readthedocsext/theme/templates/profiles/private/token_list.html
@@ -2,11 +2,23 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "API tokens" %}{% endblock %}
+{% block title %}
+  {% trans "API tokens" %}
+{% endblock %}
 {% block profile_admin_tokens %}active{% endblock %}
-{% block edit_content_header %} {% trans "API tokens" %} {% endblock %}
+{% block edit_content_header %}
+  {% trans "API tokens" %}
+{% endblock %}
+{% block edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage API tokens for authenticating with the Read the Docs API.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/api/v3.html" text=_("Learn more") is_external=True %}
+{% endblock edit_content_subheader %}
 
-{% block edit_sidebar_embed_doc %}api/v3{% endblock edit_sidebar_embed_doc %}
+{% block edit_sidebar_embed_doc %}
+  api/v3
+{% endblock edit_sidebar_embed_doc %}
 
 {% block edit_content %}
   {% include "profiles/partials/token_list.html" with objects=object_list %}

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -13,6 +13,13 @@
 {% block project_edit_content_header %}
   {% trans "Addons" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Configure features on your project's hosted documentation,
+    such as the flyout menu, search, analytics, and more.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/addons.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_sidebar_help_topics %}
   {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/addons.html" text="Addons documentation" is_external=True class="item" %}

--- a/readthedocsext/theme/templates/projects/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/automation_rule_list.html
@@ -2,10 +2,20 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Automation Rules" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Automation Rules" %}
+{% endblock %}
 
 {% block project_automation_rules_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Automation Rules" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Automation Rules" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Automatically manage versions when new tags or branches are created in your repository.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/automation-rules.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/automation_rule_list.html" with objects=object_list %}

--- a/readthedocsext/theme/templates/projects/domain_list.html
+++ b/readthedocsext/theme/templates/projects/domain_list.html
@@ -12,6 +12,12 @@
 {% block project_edit_content_header %}
   {% trans "Domains" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Serve your documentation on a custom domain.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/custom-domains.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% comment %}

--- a/readthedocsext/theme/templates/projects/environmentvariable_list.html
+++ b/readthedocsext/theme/templates/projects/environmentvariable_list.html
@@ -12,6 +12,12 @@
 {% block project_edit_content_header %}
   {% trans "Environment variables" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage custom environment variables that are available during your documentation builds.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/environment-variables.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/environment_variable_list.html" with objects=object_list %}

--- a/readthedocsext/theme/templates/projects/integration_list.html
+++ b/readthedocsext/theme/templates/projects/integration_list.html
@@ -12,6 +12,12 @@
 {% block project_edit_content_header %}
   {% trans "Integrations" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage incoming webhooks from your Git provider to trigger builds automatically.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/reference/git-integration.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/integration_list.html" with objects=subclassed_object_list %}

--- a/readthedocsext/theme/templates/projects/notification_list.html
+++ b/readthedocsext/theme/templates/projects/notification_list.html
@@ -3,10 +3,20 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Notifications" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Notifications" %}
+{% endblock %}
 
 {% block project_notifications_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Notifications" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Notifications" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Configure email addresses that receive notifications when documentation builds fail.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/build-notifications.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/notification_email_list.html" with objects=emails %}

--- a/readthedocsext/theme/templates/projects/projectrelationship_list.html
+++ b/readthedocsext/theme/templates/projects/projectrelationship_list.html
@@ -2,19 +2,27 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Subprojects" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Subprojects" %}
+{% endblock %}
 
 {% block project_subprojects_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Subprojects" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Subprojects" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Host multiple documentation projects as sub-paths on a single domain.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/subprojects.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% if superproject %}
     <div class="ui icon message">
       <i class="fa-duotone fa-circle-exclamation icon"></i>
       <div class="content">
-        <div class="header">
-          {% trans "Nested subprojects are not supported" %}
-        </div>
+        <div class="header">{% trans "Nested subprojects are not supported" %}</div>
         <p>
           {% blocktrans trimmed with project=superproject.name %}
             This project is already configured as a subproject of {{ project }}.

--- a/readthedocsext/theme/templates/projects/pull_requests_form.html
+++ b/readthedocsext/theme/templates/projects/pull_requests_form.html
@@ -4,23 +4,28 @@
 {% load static %}
 {% load crispy_forms_filters %}
 
-{% block title %}{% trans "Pull request builds" %}{% endblock %}
+{% block title %}
+  {% trans "Pull request builds" %}
+{% endblock %}
 
 {% block project_pull_requests_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Pull request builds" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Pull request builds" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Build documentation for pull requests to preview changes before merging.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/pull-requests.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
-  <p>
-    {% blocktrans trimmed %}
-      Enable builds for your pull requests and easily preview changes to your documentation.
-    {% endblocktrans %}
-  </p>
-
   <form class="ui form" method="post" action=".">
     {% csrf_token %}
     {{ form | crispy }}
 
-    <input class="ui {% if form.errors and form.is_disabled %}disabled{% endif %} primary button" type="submit"
+    <input class="ui {% if form.errors and form.is_disabled %}disabled{% endif %} primary button"
+           type="submit"
            value="{% trans " Update" %}">
   </form>
 {% endblock %}

--- a/readthedocsext/theme/templates/projects/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/redirect_list.html
@@ -3,10 +3,20 @@
 {% load i18n %}
 {% load ext_theme_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Redirects" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Redirects" %}
+{% endblock %}
 
 {% block project_redirects_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Redirects" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Redirects" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage URL redirects to send readers from old URLs to new locations.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/user-defined-redirects.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/redirect_list.html" with objects=redirects %}

--- a/readthedocsext/theme/templates/projects/search_analytics.html
+++ b/readthedocsext/theme/templates/projects/search_analytics.html
@@ -11,6 +11,12 @@
 {% block project_edit_content_header %}
   {% trans "Search Analytics" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    View what readers are searching for in your documentation and identify content gaps.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/search-analytics.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% comment %}

--- a/readthedocsext/theme/templates/projects/settings_basics_form.html
+++ b/readthedocsext/theme/templates/projects/settings_basics_form.html
@@ -9,6 +9,12 @@
 {% block project_edit_content_header %}
   {% trans "Settings" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Configure your project's name, repository, and default settings.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/intro/add-project.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 {% block project_edit_active %}
   active
 {% endblock project_edit_active %}

--- a/readthedocsext/theme/templates/projects/temporary_access_list.html
+++ b/readthedocsext/theme/templates/projects/temporary_access_list.html
@@ -3,10 +3,20 @@
 {% load i18n %}
 {% load ext_theme_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Sharing" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Sharing" %}
+{% endblock %}
 
 {% block project_access_tokens_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Sharing" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Sharing" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Create temporary access links to share private documentation with people outside your organization.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/commercial/sharing.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/temporary_access_list.html" with objects=object_list %}

--- a/readthedocsext/theme/templates/projects/traffic_analytics.html
+++ b/readthedocsext/theme/templates/projects/traffic_analytics.html
@@ -11,6 +11,12 @@
 {% block project_edit_content_header %}
   {% trans "Traffic Analytics" %}
 {% endblock project_edit_content_header %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    View the most visited pages and track traffic trends across your documentation.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/traffic-analytics.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% comment %}

--- a/readthedocsext/theme/templates/projects/translation_list.html
+++ b/readthedocsext/theme/templates/projects/translation_list.html
@@ -3,10 +3,20 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Translations" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Translations" %}
+{% endblock %}
 
 {% block project_translations_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Translations" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Translations" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage translations of your documentation to serve content in multiple languages.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/localization.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% if not project.supports_translations %}
@@ -14,44 +24,40 @@
     <div class="ui icon message">
       <i class="fa-duotone fa-circle-exclamation icon"></i>
       <div class="content">
-        <div class="header">
-          {% trans "Translations are not supported" %}
-        </div>
+        <div class="header">{% trans "Translations are not supported" %}</div>
         <p>
           {% blocktrans trimmed with project_settings_url=project_settings_url %}
             This project is <a href="{{ project_settings_url }}">configured</a> with a versioning scheme that doesn't support translations.
           {% endblocktrans %}
         </p>
       </div>
-  {% elif project.main_language_project %}
-    <div class="ui icon message">
-      <i class="fa-duotone fa-diagram-nested icon"></i>
-      <div class="content">
-        <div class="header">
-          {% trans "Nested translations are not supported" %}
-        </div>
-        <p>
-          {% blocktrans trimmed with language=project.get_language_display  main_project=project.main_language_project.name %}
-            This project is already configured as the {{ language }} translation of
-            "{{ main_project }}".
-          {% endblocktrans %}
-        </p>
-
-        <p>
-          <a href="{% url 'projects_translations' project_slug=project.main_language_project.slug %}">
-            {% blocktrans trimmed with main_project=project.main_language_project.name %}
-              View all translations of "{{ main_project }}".
+    {% elif project.main_language_project %}
+      <div class="ui icon message">
+        <i class="fa-duotone fa-diagram-nested icon"></i>
+        <div class="content">
+          <div class="header">{% trans "Nested translations are not supported" %}</div>
+          <p>
+            {% blocktrans trimmed with language=project.get_language_display  main_project=project.main_language_project.name %}
+              This project is already configured as the {{ language }} translation of
+              "{{ main_project }}".
             {% endblocktrans %}
-          </a>
-        </p>
-      </div>
-    </div>
-  {% else %}
-    {% include "projects/partials/edit/translation_list.html" with objects=lang_projects %}
-  {% endif %}
-{% endblock %}
+          </p>
 
-{% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/localization.html" text="Localization of documentation" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/manage-translations-sphinx.html" text="How to manage translations for Sphinx projects" is_external=True class="item" %}
-{% endblock project_edit_sidebar_help_topics %}
+          <p>
+            <a href="{% url 'projects_translations' project_slug=project.main_language_project.slug %}">
+              {% blocktrans trimmed with main_project=project.main_language_project.name %}
+                View all translations of "{{ main_project }}".
+              {% endblocktrans %}
+            </a>
+          </p>
+        </div>
+      </div>
+    {% else %}
+      {% include "projects/partials/edit/translation_list.html" with objects=lang_projects %}
+    {% endif %}
+  {% endblock %}
+
+  {% block project_edit_sidebar_help_topics %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/localization.html" text="Localization of documentation" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/manage-translations-sphinx.html" text="How to manage translations for Sphinx projects" is_external=True class="item" %}
+  {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/user_list.html
+++ b/readthedocsext/theme/templates/projects/user_list.html
@@ -3,10 +3,20 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Maintainers" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Maintainers" %}
+{% endblock %}
 
 {% block project_users_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Maintainers" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Maintainers" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Manage the users who have access to this project's settings and builds.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/managing-maintainers.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/user_list.html" with objects=users %}
@@ -33,9 +43,7 @@
     {% if invitations.exists %}
       <h2 class="ui small header">
         {% trans "Pending invitations" %}
-        <span class="ui circular small label">
-          {{ invitations.count }}
-        </span>
+        <span class="ui circular small label">{{ invitations.count }}</span>
       </h2>
       {% include "invitations/partials/invitation_list.html" with objects=invitations skip_pagination=True %}
     {% endif %}

--- a/readthedocsext/theme/templates/projects/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/webhook_list.html
@@ -3,10 +3,20 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Webhooks" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Webhooks" %}
+{% endblock %}
 
 {% block project_webhooks_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Webhooks" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Webhooks" %}
+{% endblock %}
+{% block project_edit_content_subheader %}
+  {% blocktrans trimmed %}
+    Send HTTP requests to external services when events occur on your project.
+  {% endblocktrans %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.com/platform/stable/guides/build/webhooks.html" text=_("Learn more") is_external=True %}
+{% endblock project_edit_content_subheader %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/webhook_list.html" with objects=object_list %}


### PR DESCRIPTION
## Summary

- Add a brief description and "Learn more" doc link in the subheader of every settings page
- Uses the existing but previously unused `project_edit_content_subheader` block
- Remove duplicate inline `<p>` descriptions from Pull Requests and Authorization pages (now in subheader)
- 22 pages updated across project, organization, and profile settings

## Test plan

- [ ] Check each settings page renders the subheader text and "Learn more" link
- [ ] Verify "Learn more" links resolve correctly
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.ai/code)

Made by AI.