### PR TITLE
Audit and improve help links across settings pages

### DIFF
--- a/readthedocsext/theme/templates/organizations/settings/organization_edit.html
+++ b/readthedocsext/theme/templates/organizations/settings/organization_edit.html
@@ -14,6 +14,10 @@
   {% trans "Details" %}
 {% endblock organization_edit_content_header %}
 
+{% block organization_edit_sidebar_help_topics %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/commercial/organizations.html" text=_("Organizations") is_external=True class="item" %}
+{% endblock organization_edit_sidebar_help_topics %}
+
 {% block organization_edit_content %}
   <form class="ui form"
         method="post"

--- a/readthedocsext/theme/templates/organizations/settings/saml.html
+++ b/readthedocsext/theme/templates/organizations/settings/saml.html
@@ -8,8 +8,8 @@
 {% endblock organization_edit_content_subheader %}
 
 {% block organization_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/guides/set-up-single-sign-on-saml.html" text=_("How to set up single sign-on with SAML") is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/set-up-single-sign-on-saml.html" text=_("Setting up SAML single sign-on") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/commercial/single-sign-on.html" text=_("Single sign-on") is_external=True class="item" %}
 {% endblock organization_edit_sidebar_help_topics %}
 
 {% block organization_edit_content %}

--- a/readthedocsext/theme/templates/organizations/settings/sso_edit.html
+++ b/readthedocsext/theme/templates/organizations/settings/sso_edit.html
@@ -16,7 +16,7 @@
 {% endblock organization_edit_content_header %}
 
 {% block organization_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/commercial/single-sign-on.html" text=_("Organization single sign-on") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/commercial/single-sign-on.html" text=_("Single sign-on") is_external=True class="item" %}
 {% endblock organization_edit_sidebar_help_topics %}
 
 {% block organization_edit_content %}

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -15,9 +15,9 @@
 {% endblock project_edit_content_header %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/addons.html" text="Addons documentation" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://about.readthedocs.com/blog/2024/04/enable-beta-addons/" text="Blog post: Empower your documentation with addons" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://blog.readthedocs.com/addons-flyout-menu-beta/" text="Blog post: Addons flyout menu beta" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/addons.html" text=_("Addons") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/flyout-menu.html" text=_("Flyout menu") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/visual-diff.html" text=_("Visual diff") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}
 
 {% block project_edit_content %}

--- a/readthedocsext/theme/templates/projects/automation_rule_list.html
+++ b/readthedocsext/theme/templates/projects/automation_rule_list.html
@@ -2,10 +2,14 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Automation Rules" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Automation Rules" %}
+{% endblock %}
 
 {% block project_automation_rules_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Automation Rules" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Automation Rules" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/automation_rule_list.html" with objects=object_list %}
@@ -13,6 +17,6 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/automation-rules.html" text="Automation rules" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/automation-rules.html" text=_("Automation rules") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text=_("Managing versions automatically") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/domain_list.html
+++ b/readthedocsext/theme/templates/projects/domain_list.html
@@ -30,7 +30,7 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/custom-domains.html" text="How to manage custom domains" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/subprojects.html" text="Subprojects: host multiple projects on a single domain" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html#canonical-urls" text="Canonical URLs and domains" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/custom-domains.html" text=_("Custom domains") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/custom-domains.html" text=_("Managing custom domains") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/canonical-urls.html" text=_("Canonical URLs") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/environmentvariable_list.html
+++ b/readthedocsext/theme/templates/projects/environmentvariable_list.html
@@ -18,7 +18,7 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/environment-variables.html" text="How to use custom environment variables" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/environment-variables.html" text="Understanding environment variables" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/reference/environment-variables.html" text="Predefined environment variables" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/environment-variables.html" text=_("Environment variables") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/environment-variables.html" text=_("Using custom environment variables") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/reference/environment-variables.html" text=_("Predefined environment variables") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/integration_list.html
+++ b/readthedocsext/theme/templates/projects/integration_list.html
@@ -18,6 +18,6 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/connecting-git-account.html" text="How to connect your Read the Docs account to your Git provider" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/en/stable/guides/setup/git-repo-automatic.html" text="How to automatically configure a Git repository" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/reference/git-integration.html" text=_("Git integration reference") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/connecting-git-account.html" text=_("Connecting your Git account") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/notification_list.html
+++ b/readthedocsext/theme/templates/projects/notification_list.html
@@ -3,15 +3,20 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Notifications" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Notifications" %}
+{% endblock %}
 
 {% block project_notifications_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Notifications" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Notifications" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/notification_email_list.html" with objects=emails %}
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/build-notifications.html" text="How to set up build notifications" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/build-notifications.html" text=_("Build notifications") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/build/email-notifications.html" text=_("Configuring email notifications") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/projectrelationship_list.html
+++ b/readthedocsext/theme/templates/projects/projectrelationship_list.html
@@ -2,19 +2,21 @@
 
 {% load i18n %}
 
-{% block title %}{{ project.name }} - {% trans "Subprojects" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Subprojects" %}
+{% endblock %}
 
 {% block project_subprojects_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Subprojects" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Subprojects" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% if superproject %}
     <div class="ui icon message">
       <i class="fa-duotone fa-circle-exclamation icon"></i>
       <div class="content">
-        <div class="header">
-          {% trans "Nested subprojects are not supported" %}
-        </div>
+        <div class="header">{% trans "Nested subprojects are not supported" %}</div>
         <p>
           {% blocktrans trimmed with project=superproject.name %}
             This project is already configured as a subproject of {{ project }}.
@@ -36,5 +38,6 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/subprojects.html" text="Subprojects: host multiple projects on a single domain" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/subprojects.html" text=_("Subprojects") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/subprojects.html" text=_("Managing subprojects") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/pull_requests_form.html
+++ b/readthedocsext/theme/templates/projects/pull_requests_form.html
@@ -4,10 +4,14 @@
 {% load static %}
 {% load crispy_forms_filters %}
 
-{% block title %}{% trans "Pull request builds" %}{% endblock %}
+{% block title %}
+  {% trans "Pull request builds" %}
+{% endblock %}
 
 {% block project_pull_requests_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Pull request builds" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Pull request builds" %}
+{% endblock %}
 
 {% block project_edit_content %}
   <p>
@@ -20,11 +24,13 @@
     {% csrf_token %}
     {{ form | crispy }}
 
-    <input class="ui {% if form.errors and form.is_disabled %}disabled{% endif %} primary button" type="submit"
+    <input class="ui {% if form.errors and form.is_disabled %}disabled{% endif %} primary button"
+           type="submit"
            value="{% trans " Update" %}">
   </form>
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/pull-requests.html" text="Pull request builds" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/pull-requests.html" text=_("Pull request builds") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/pull-requests.html" text=_("Configuring pull request builds") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/redirect_list.html
@@ -3,17 +3,21 @@
 {% load i18n %}
 {% load ext_theme_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Redirects" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Redirects" %}
+{% endblock %}
 
 {% block project_redirects_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Redirects" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Redirects" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/redirect_list.html" with objects=redirects %}
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/redirects.html" text="How to use custom URL redirects in documentation projects" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/user-defined-redirects.html" text="Custom and built-in redirects on Read the Docs" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/best-practice/links.html" text="Best practices for linking to your documentation" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/user-defined-redirects.html" text=_("Redirect types and options") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/redirects.html" text=_("Using custom redirects") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/best-practice/links.html" text=_("Best practices for links") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/search_analytics.html
+++ b/readthedocsext/theme/templates/projects/search_analytics.html
@@ -69,6 +69,6 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/search-analytics.html" text="How to use search analytics" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html" text="How to do search engine optimization (SEO) for documentation projects" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/search-analytics.html" text=_("Search analytics") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html" text=_("SEO for documentation projects") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/settings_basics_form.html
+++ b/readthedocsext/theme/templates/projects/settings_basics_form.html
@@ -71,16 +71,14 @@
 {% block project_edit_sidebar_help_topics_content %}
   <div class="ui mini header">{% trans "Tutorials" %}</div>
   <div class="ui bulleted list">
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text="Getting started" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text="Importing your documentation" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/doctools.html" text="Quickstart with popular tools" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/tutorial/index.html" text=_("Getting started") is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/import-guide.html" text=_("Adding a project") is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/intro/doctools.html" text=_("Popular documentation tools") is_external=True class="item" %}
   </div>
   <div class="ui mini header">{% trans "Resources" %}</div>
   <div class="ui bulleted list">
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/v2.html" text="Configuration file" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/pull-requests.html" text="How to configure pull request builds" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/automation-rules.html" text="How to manage versions automatically" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/setup/monorepo.html" text="How to use a .readthedocs.yaml file in a sub-folder" is_external=True class="item" %}
-    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/versioning-schemes.html" text="URL versioning schemes" is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/config-file/v2.html" text=_("Configuration file") is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/versioning-schemes.html" text=_("Versioning schemes") is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/build-customization.html" text=_("Build customization") is_external=True class="item" %}
   </div>
 {% endblock project_edit_sidebar_help_topics_content %}

--- a/readthedocsext/theme/templates/projects/traffic_analytics.html
+++ b/readthedocsext/theme/templates/projects/traffic_analytics.html
@@ -77,6 +77,6 @@
 {% endblock project_edit_content %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/analytics.html" text="How to use traffic analytics" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html" text="How to do search engine optimization (SEO) for documentation projects" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/traffic-analytics.html" text=_("Traffic analytics") is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/technical-docs-seo-guide.html" text=_("SEO for documentation projects") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/translation_list.html
+++ b/readthedocsext/theme/templates/projects/translation_list.html
@@ -3,10 +3,14 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Translations" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Translations" %}
+{% endblock %}
 
 {% block project_translations_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Translations" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Translations" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% if not project.supports_translations %}
@@ -14,44 +18,40 @@
     <div class="ui icon message">
       <i class="fa-duotone fa-circle-exclamation icon"></i>
       <div class="content">
-        <div class="header">
-          {% trans "Translations are not supported" %}
-        </div>
+        <div class="header">{% trans "Translations are not supported" %}</div>
         <p>
           {% blocktrans trimmed with project_settings_url=project_settings_url %}
             This project is <a href="{{ project_settings_url }}">configured</a> with a versioning scheme that doesn't support translations.
           {% endblocktrans %}
         </p>
       </div>
-  {% elif project.main_language_project %}
-    <div class="ui icon message">
-      <i class="fa-duotone fa-diagram-nested icon"></i>
-      <div class="content">
-        <div class="header">
-          {% trans "Nested translations are not supported" %}
-        </div>
-        <p>
-          {% blocktrans trimmed with language=project.get_language_display  main_project=project.main_language_project.name %}
-            This project is already configured as the {{ language }} translation of
-            "{{ main_project }}".
-          {% endblocktrans %}
-        </p>
-
-        <p>
-          <a href="{% url 'projects_translations' project_slug=project.main_language_project.slug %}">
-            {% blocktrans trimmed with main_project=project.main_language_project.name %}
-              View all translations of "{{ main_project }}".
+    {% elif project.main_language_project %}
+      <div class="ui icon message">
+        <i class="fa-duotone fa-diagram-nested icon"></i>
+        <div class="content">
+          <div class="header">{% trans "Nested translations are not supported" %}</div>
+          <p>
+            {% blocktrans trimmed with language=project.get_language_display  main_project=project.main_language_project.name %}
+              This project is already configured as the {{ language }} translation of
+              "{{ main_project }}".
             {% endblocktrans %}
-          </a>
-        </p>
-      </div>
-    </div>
-  {% else %}
-    {% include "projects/partials/edit/translation_list.html" with objects=lang_projects %}
-  {% endif %}
-{% endblock %}
+          </p>
 
-{% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/localization.html" text="Localization of documentation" is_external=True class="item" %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/manage-translations-sphinx.html" text="How to manage translations for Sphinx projects" is_external=True class="item" %}
-{% endblock project_edit_sidebar_help_topics %}
+          <p>
+            <a href="{% url 'projects_translations' project_slug=project.main_language_project.slug %}">
+              {% blocktrans trimmed with main_project=project.main_language_project.name %}
+                View all translations of "{{ main_project }}".
+              {% endblocktrans %}
+            </a>
+          </p>
+        </div>
+      </div>
+    {% else %}
+      {% include "projects/partials/edit/translation_list.html" with objects=lang_projects %}
+    {% endif %}
+  {% endblock %}
+
+  {% block project_edit_sidebar_help_topics %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/localization.html" text=_("Localization and translations") is_external=True class="item" %}
+    {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/manage-translations-sphinx.html" text=_("Managing translations for Sphinx") is_external=True class="item" %}
+  {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/user_list.html
+++ b/readthedocsext/theme/templates/projects/user_list.html
@@ -3,10 +3,14 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Maintainers" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Maintainers" %}
+{% endblock %}
 
 {% block project_users_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Maintainers" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Maintainers" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/user_list.html" with objects=users %}
@@ -33,9 +37,7 @@
     {% if invitations.exists %}
       <h2 class="ui small header">
         {% trans "Pending invitations" %}
-        <span class="ui circular small label">
-          {{ invitations.count }}
-        </span>
+        <span class="ui circular small label">{{ invitations.count }}</span>
       </h2>
       {% include "invitations/partials/invitation_list.html" with objects=invitations skip_pagination=True %}
     {% endif %}
@@ -43,5 +45,5 @@
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/glossary.html#term-maintainer" text="What is a maintainer?" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/managing-maintainers.html" text=_("Managing maintainers") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}

--- a/readthedocsext/theme/templates/projects/webhook_list.html
+++ b/readthedocsext/theme/templates/projects/webhook_list.html
@@ -3,15 +3,19 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}{{ project.name }} - {% trans "Webhooks" %}{% endblock %}
+{% block title %}
+  {{ project.name }} - {% trans "Webhooks" %}
+{% endblock %}
 
 {% block project_webhooks_active %}active{% endblock %}
-{% block project_edit_content_header %}{% trans "Webhooks" %}{% endblock %}
+{% block project_edit_content_header %}
+  {% trans "Webhooks" %}
+{% endblock %}
 
 {% block project_edit_content %}
   {% include "projects/partials/edit/webhook_list.html" with objects=object_list %}
 {% endblock %}
 
 {% block project_edit_sidebar_help_topics %}
-  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/build-notifications.html" text="How to setup build notifications and webhooks" is_external=True class="item" %}
+  {% include "includes/elements/link.html" with url="https://docs.readthedocs.io/page/guides/build/webhooks.html" text=_("Configuring outgoing webhooks") is_external=True class="item" %}
 {% endblock project_edit_sidebar_help_topics %}


### PR DESCRIPTION
## Summary

- Standardize link text to concise noun phrases, wrapped in `_()` for translation
- Reorder links: reference page first, then how-to guide
- Replace blog post links on Addons page with actual doc links (flyout menu, visual diff)
- Add missing help links: Notifications, Pull Requests, Subprojects, Organization Details
- Fix broken link targets (analytics, search-analytics, build-notifications)
- Fix `/en/stable/` URLs to use `/page/` format on SSO and SAML pages

## Test plan

- [ ] Check sidebar help links on each settings page
- [ ] Verify all links resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Made by AI.