### PR TITLE
projects: surface options_base_version and add redirect filter

### DIFF
--- a/readthedocsext/theme/templates/includes/filters/form.html
+++ b/readthedocsext/theme/templates/includes/filters/form.html
@@ -8,6 +8,18 @@
         <input type="hidden"
                name="{{ field.name }}"
                value="{% if field.value.0|length == 1 %}{{ field.value|default:"" }}{% else %}{{ field.value.0|default:"" }}{% endif %}" />
+      {% elif field.field.widget.input_type == "text" %}
+        <div class="item">
+          <div class="content">
+            <div class="ui icon input">
+              <input type="text"
+                     name="{{ field.name }}"
+                     value="{{ field.value|default:"" }}"
+                     placeholder="{{ field.label }}" />
+              <i class="fa-solid fa-magnifying-glass icon"></i>
+            </div>
+          </div>
+        </div>
       {% else %}
         <div class="item">
           <div class="content">

--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -105,6 +105,7 @@
         <div class="ui tab" data-tab="filetreediff">
           {{ form.filetreediff_enabled | as_crispy_field }}
           {{ form.filetreediff_ignored_files | as_crispy_field }}
+          {{ form.options_base_version | as_crispy_field }}
         </div>
       {% endblock addons_filetreediff %}
 

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -3,6 +3,9 @@
 {% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
+  <div data-bind="using: FilterView()">
+    {% include "includes/filters/form.html" with fields=filter.form %}
+  </div>
 {% endblock top_left_menu_items %}
 
 {% block create_button %}


### PR DESCRIPTION
Superseded by #729 and #730, matching the upstream split of readthedocs/readthedocs.org#12970 into readthedocs/readthedocs.org#12971 and readthedocs/readthedocs.org#12972.

---

Generated by Copilot.