### PR TITLE
projects: surface options_base_version in addons form

### DIFF
--- a/readthedocsext/theme/templates/projects/addons_form.html
+++ b/readthedocsext/theme/templates/projects/addons_form.html
@@ -105,6 +105,7 @@
         <div class="ui tab" data-tab="filetreediff">
           {{ form.filetreediff_enabled | as_crispy_field }}
           {{ form.filetreediff_ignored_files | as_crispy_field }}
+          {{ form.options_base_version | as_crispy_field }}
         </div>
       {% endblock addons_filetreediff %}
 


### PR DESCRIPTION
Companion template change for readthedocs/readthedocs.org#12971.

Renders the new `options_base_version` field in the File Tree Diff tab of the addons form.

Related: readthedocs/readthedocs.org#12971

---

Generated by Copilot.