### PR TITLE
projects: add filter to redirect list view

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -3,6 +3,9 @@
 {% load trans blocktrans from i18n %}
 
 {% block top_left_menu_items %}
+  <div data-bind="using: FilterView()">
+    {% include "includes/filters/form.html" with fields=filter.form %}
+  </div>
 {% endblock top_left_menu_items %}
 
 {% block create_button %}


### PR DESCRIPTION
Companion template changes for readthedocs/readthedocs.org#12972.

- Wire filter controls (redirect type dropdown, URL search) onto the redirect list page.
- Extend `includes/filters/form.html` to render a Semantic UI text input for `CharFilter` fields, alongside the existing hidden/dropdown branches.

Related: readthedocs/readthedocs.org#12972

---

Generated by Copilot.