### PR TITLE
redirects: show correct empty state when filtering to no results

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -17,20 +17,23 @@
 {% block list_placeholder_icon_class %}
   fa-duotone fa-signs-post
 {% endblock list_placeholder_icon_class %}
-{% block list_placeholder_header %}
+{% block list_placeholder_header_filtered %}
+  {% trans "No matching redirects found" %}
+{% endblock list_placeholder_header_filtered %}
+{% block list_placeholder_header_empty %}
   {% blocktrans trimmed %}
     No redirects exist yet
   {% endblocktrans %}
   <div class="sub header">
     {% trans "Redirects allow you to fix links to pages that have moved." %}
   </div>
-{% endblock list_placeholder_header %}
-{% block list_placeholder_text %}
+{% endblock list_placeholder_header_empty %}
+{% block list_placeholder_text_empty %}
   <a class="ui button"
      href="https://docs.readthedocs.io/page/guides/redirects.html"
      target="_blank"
      aria-label="{% trans "Learn more about custom redirects in our documentation" %}">{% trans "Learn more" %}</a>
-{% endblock list_placeholder_text %}
+{% endblock list_placeholder_text_empty %}
 
 {% block list_item_right_buttons %}
   {% trans "Move up" as button_up_text %}

--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -32,6 +32,7 @@
   <a class="ui button"
      href="https://docs.readthedocs.io/page/guides/redirects.html"
      target="_blank"
+     rel="nofollow noopener noreferrer"
      aria-label="{% trans "Learn more about custom redirects in our documentation" %}">{% trans "Learn more" %}</a>
 {% endblock list_placeholder_text_empty %}
 


### PR DESCRIPTION
The redirect list has a filter but overrode the parent `list_placeholder_header` / `list_placeholder_text` blocks. That bypasses the filtered-vs-empty logic in `table_list.html`, so filtering an existing list down to zero matches showed the "No redirects exist yet" onboarding message (with a docs link) instead of a no-results message.

Switched to the filter-aware `list_placeholder_header_empty` / `list_placeholder_header_filtered` / `list_placeholder_text_empty` variants, matching the pattern already used by the project, build, and version lists. The truly-empty onboarding content is unchanged.

## Old

<img width="1382" height="765" alt="Screenshot 2026-06-03 at 12 13 23 PM" src="https://github.com/user-attachments/assets/004117cc-70ca-49de-81d6-a529ff3602fc" />

## New

<img width="1279" height="744" alt="Screenshot 2026-06-03 at 12 14 53 PM" src="https://github.com/user-attachments/assets/4efa8153-e19e-452e-9f89-1359aef78679" />


---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tb9Ea7oNTCDqt3huHWu6Pa)_