### PR TITLE
theme: don't open the GitHub App skip-step link in a new tab

### DIFF
--- a/readthedocsext/theme/templates/profiles/partials/github_app_target_list.html
+++ b/readthedocsext/theme/templates/profiles/partials/github_app_target_list.html
@@ -26,8 +26,7 @@
 {% block list_placeholder_text %}
   <a class="ui button"
      href="?step=revoke"
-     aria-label="{% trans "Skip this step" %}"
-     target="_blank">{% trans "Skip this step" %}</a>
+     aria-label="{% trans "Skip this step" %}">{% trans "Skip this step" %}</a>
 {% endblock list_placeholder_text %}
 
 {% block top_right_menu_items %}


### PR DESCRIPTION
The "Skip this step" link in the GitHub App installation-target empty state used `target="_blank"`, but it navigates within the same migration flow (`?step=revoke`). Opening it in a new tab leaves the original tab on the previous step. Removed `target="_blank"` so it navigates in place.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tb9Ea7oNTCDqt3huHWu6Pa)_