### PR TITLE
Fix profile menu not highlighting dashboard preferences

### DIFF
--- a/readthedocsext/theme/templates/profiles/private/dashboard_preferences_form.html
+++ b/readthedocsext/theme/templates/profiles/private/dashboard_preferences_form.html
@@ -6,9 +6,9 @@
 {% block title %}
   {% trans "Dashboard preferences" %}
 {% endblock title %}
-{% block profile_admin_preferences %}
+{% block profile_admin_dashboard_preferences %}
   active
-{% endblock profile_admin_preferences %}
+{% endblock profile_admin_dashboard_preferences %}
 {% block edit_content_header %}
   {% trans "Dashboard preferences" %}
 {% endblock edit_content_header %}


### PR DESCRIPTION

Block name changed and wasn't updated. It is currently not showing as
highlighted when you click on it.
