### PR TITLE
Builds: Add OpenGraph meta tags for Slack/social link previews

### DIFF
--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -14,12 +14,14 @@
       <meta name="description"
             content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta name="keywords" content="documentation hosting" />
+      <link rel="canonical" href="{{ request.build_absolute_uri }}" />
       <meta property="og:title" content="Read the Docs" />
       <meta property="og:description"
             content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta property="og:url" content="{{ request.build_absolute_uri }}" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Read the Docs" />
+      <meta name="twitter:card" content="summary" />
     {% endblock head_meta %}
 
     {% block head_links %}

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -11,12 +11,10 @@
     {# djlint:on #}
 
     {% block head_meta %}
-      <meta name="description"
-            content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta name="keywords" content="documentation hosting" />
       {# djlint:off #}
       <meta property="og:title" content="{% block meta_title %}Read the Docs{% endblock meta_title %}" />
-      <meta property="og:description" content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
+      <meta name="description" property="og:description" content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
       {# djlint:on #}
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Read the Docs" />

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -14,10 +14,9 @@
       <meta name="description"
             content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta name="keywords" content="documentation hosting" />
-      <meta property="og:title"
-            content="{% block meta_title %}Read the Docs{% endblock meta_title %}" />
+      <meta property="og:title" content="Read the Docs" />
       <meta property="og:description"
-            content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
+            content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta property="og:url" content="{{ request.build_absolute_uri }}" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Read the Docs" />

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -14,6 +14,12 @@
       <meta name="description"
             content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta name="keywords" content="documentation hosting" />
+      {# djlint:off #}
+      <meta property="og:title" content="{% block meta_title %}Read the Docs{% endblock meta_title %}" />
+      <meta property="og:description" content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
+      {# djlint:on #}
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Read the Docs" />
     {% endblock head_meta %}
 
     {% block head_links %}

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -11,11 +11,14 @@
     {# djlint:on #}
 
     {% block head_meta %}
+      <meta name="description"
+            content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta name="keywords" content="documentation hosting" />
       {# djlint:off #}
       <meta property="og:title" content="{% block meta_title %}Read the Docs{% endblock meta_title %}" />
-      <meta name="description" property="og:description" content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
+      <meta property="og:description" content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
       {# djlint:on #}
+      <meta property="og:url" content="{{ request.build_absolute_uri }}" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Read the Docs" />
     {% endblock head_meta %}

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -14,10 +14,10 @@
       <meta name="description"
             content="Read the Docs is a documentation publishing and hosting platform for technical documentation" />
       <meta name="keywords" content="documentation hosting" />
-      {# djlint:off #}
-      <meta property="og:title" content="{% block meta_title %}Read the Docs{% endblock meta_title %}" />
-      <meta property="og:description" content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
-      {# djlint:on #}
+      <meta property="og:title"
+            content="{% block meta_title %}Read the Docs{% endblock meta_title %}" />
+      <meta property="og:description"
+            content="{% block meta_description %}Read the Docs is a documentation publishing and hosting platform for technical documentation{% endblock meta_description %}" />
       <meta property="og:url" content="{{ request.build_absolute_uri }}" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Read the Docs" />

--- a/readthedocsext/theme/templates/base.html
+++ b/readthedocsext/theme/templates/base.html
@@ -21,7 +21,6 @@
       <meta property="og:url" content="{{ request.build_absolute_uri }}" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Read the Docs" />
-      <meta name="twitter:card" content="summary" />
     {% endblock head_meta %}
 
     {% block head_links %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -7,10 +7,16 @@
   {{ build.project.name }}
 {% endblock title %}
 
-{# djlint:off #}
-{% block meta_title %}{% blocktrans with pk=build.pk name=build.project.name %}Build #{{ pk }} - {{ name }}{% endblocktrans %}{% endblock meta_title %}
-{% block meta_description %}{% blocktrans with result=build.get_result_display version=build.get_version_name project=build.project.name %}{{ result }} for {{ version }} on {{ project }}{% endblocktrans %}{% endblock meta_description %}
-{# djlint:on #}
+{% block head_meta %}
+  {% blocktrans with pk=build.pk name=build.project.name asvar og_title %}Build #{{ pk }} - {{ name }}{% endblocktrans %}
+  {% blocktrans with result=build.get_result_display version=build.get_version_name project=build.project.name asvar og_description %}{{ result }} for {{ version }} on {{ project }}{% endblocktrans %}
+  <meta name="description" content="{{ og_description }}" />
+  <meta property="og:title" content="{{ og_title }}" />
+  <meta property="og:description" content="{{ og_description }}" />
+  <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Read the Docs" />
+{% endblock head_meta %}
 
 {% block content-header %}
   {% include "projects/partials/header.html" with builds_active="active" %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -9,7 +9,7 @@
 
 {# djlint:off #}
 {% block meta_title %}Build #{{ build.pk }} - {{ build.project.name }}{% endblock meta_title %}
-{% block meta_description %}{% if build.state == "finished" %}{% if build.success %}Build passed{% else %}Build failed{% endif %}{% elif build.state == "cancelled" %}Build cancelled{% else %}Build in progress ({{ build.get_state_display }}){% endif %} for {{ build.get_version_name }} on {{ build.project.name }}{% endblock meta_description %}
+{% block meta_description %}{{ build.get_result_display }} for {{ build.get_version_name }} on {{ build.project.name }}{% endblock meta_description %}
 {# djlint:on #}
 
 {% block content-header %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -8,8 +8,8 @@
 {% endblock title %}
 
 {# djlint:off #}
-{% block meta_title %}Build #{{ build.pk }} - {{ build.project.name }}{% endblock meta_title %}
-{% block meta_description %}{{ build.get_result_display }} for {{ build.get_version_name }} on {{ build.project.name }}{% endblock meta_description %}
+{% block meta_title %}{% blocktrans with pk=build.pk name=build.project.name %}Build #{{ pk }} - {{ name }}{% endblocktrans %}{% endblock meta_title %}
+{% block meta_description %}{% blocktrans with result=build.get_result_display version=build.get_version_name project=build.project.name %}{{ result }} for {{ version }} on {{ project }}{% endblocktrans %}{% endblock meta_description %}
 {# djlint:on #}
 
 {% block content-header %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -4,7 +4,7 @@
 {% load is_admin from privacy_tags %}
 
 {% block title %}
-  {{ build.project.name }}
+  {% blocktrans with pk=build.pk name=build.project.name %}Build #{{ pk }} - {{ name }}{% endblocktrans %}
 {% endblock title %}
 
 {% block head_meta %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -7,16 +7,10 @@
   {{ build.project.name }}
 {% endblock title %}
 
-{% block head_meta %}
-  {{ block.super }}
-  <meta property="og:title"
-        content="Build #{{ build.pk }} - {{ build.project.name }}" />
-  <meta property="og:description"
-        content="{% if build.state == "finished" %}{% if build.success %}Build passed{% else %}Build failed{% endif %}{% elif build.state == "cancelled" %}Build cancelled{% else %}Build in progress ({{ build.get_state_display }}){% endif %} for {{ build.get_version_name }} on {{ build.project.name }}" />
-  <meta property="og:url" content="{{ build.get_full_url }}" />
-  <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="Read the Docs" />
-{% endblock head_meta %}
+{# djlint:off #}
+{% block meta_title %}Build #{{ build.pk }} - {{ build.project.name }}{% endblock meta_title %}
+{% block meta_description %}{% if build.state == "finished" %}{% if build.success %}Build passed{% else %}Build failed{% endif %}{% elif build.state == "cancelled" %}Build cancelled{% else %}Build in progress ({{ build.get_state_display }}){% endif %} for {{ build.get_version_name }} on {{ build.project.name }}{% endblock meta_description %}
+{# djlint:on #}
 
 {% block content-header %}
   {% include "projects/partials/header.html" with builds_active="active" %}

--- a/readthedocsext/theme/templates/builds/build_detail.html
+++ b/readthedocsext/theme/templates/builds/build_detail.html
@@ -7,6 +7,17 @@
   {{ build.project.name }}
 {% endblock title %}
 
+{% block head_meta %}
+  {{ block.super }}
+  <meta property="og:title"
+        content="Build #{{ build.pk }} - {{ build.project.name }}" />
+  <meta property="og:description"
+        content="{% if build.state == "finished" %}{% if build.success %}Build passed{% else %}Build failed{% endif %}{% elif build.state == "cancelled" %}Build cancelled{% else %}Build in progress ({{ build.get_state_display }}){% endif %} for {{ build.get_version_name }} on {{ build.project.name }}" />
+  <meta property="og:url" content="{{ build.get_full_url }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Read the Docs" />
+{% endblock head_meta %}
+
 {% block content-header %}
   {% include "projects/partials/header.html" with builds_active="active" %}
 {% endblock content-header %}

--- a/readthedocsext/theme/templates/organizations/organization_detail.html
+++ b/readthedocsext/theme/templates/organizations/organization_detail.html
@@ -1,6 +1,6 @@
 {% extends "organizations/base.html" %}
 
-{% load trans blocktrans from i18n %}
+{% load trans from i18n %}
 {% load gravatar_url from gravatar %}
 
 {% load has_sso_enabled from organizations %}
@@ -9,10 +9,17 @@
   {{ organization.name }}
 {% endblock title %}
 
-{# djlint:off #}
-{% block meta_title %}{{ organization.name }}{% endblock meta_title %}
-{% block meta_description %}{% if organization.description %}{{ organization.description }}{% else %}{% trans "Organization on Read the Docs" %}{% endif %}{% endblock meta_description %}
-{# djlint:on #}
+{% block head_meta %}
+  {% trans "Organization on Read the Docs" as default_description %}
+  <meta name="description"
+        content="{% firstof organization.description default_description %}" />
+  <meta property="og:title" content="{{ organization.name }}" />
+  <meta property="og:description"
+        content="{% firstof organization.description default_description %}" />
+  <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Read the Docs" />
+{% endblock head_meta %}
 
 {% block content-header %}
   {% include "organizations/partials/header.html" with organization=organization projects_active="active" %}

--- a/readthedocsext/theme/templates/organizations/organization_detail.html
+++ b/readthedocsext/theme/templates/organizations/organization_detail.html
@@ -7,6 +7,11 @@
 
 {% block title %}{{ organization.name }}{% endblock %}
 
+{# djlint:off #}
+{% block meta_title %}{{ organization.name }}{% endblock meta_title %}
+{% block meta_description %}{% firstof organization.description "Organization on Read the Docs" %}{% endblock meta_description %}
+{# djlint:on #}
+
 {% block content-header %}
   {% include "organizations/partials/header.html" with organization=organization projects_active="active" %}
 {% endblock %}

--- a/readthedocsext/theme/templates/organizations/organization_detail.html
+++ b/readthedocsext/theme/templates/organizations/organization_detail.html
@@ -1,6 +1,6 @@
 {% extends "organizations/base.html" %}
 
-{% load trans from i18n %}
+{% load trans blocktrans from i18n %}
 {% load gravatar_url from gravatar %}
 
 {% load has_sso_enabled from organizations %}
@@ -11,7 +11,7 @@
 
 {# djlint:off #}
 {% block meta_title %}{{ organization.name }}{% endblock meta_title %}
-{% block meta_description %}{% firstof organization.description "Organization on Read the Docs" %}{% endblock meta_description %}
+{% block meta_description %}{% if organization.description %}{{ organization.description }}{% else %}{% trans "Organization on Read the Docs" %}{% endif %}{% endblock meta_description %}
 {# djlint:on #}
 
 {% block content-header %}

--- a/readthedocsext/theme/templates/organizations/organization_detail.html
+++ b/readthedocsext/theme/templates/organizations/organization_detail.html
@@ -1,11 +1,13 @@
 {% extends "organizations/base.html" %}
 
-{% load i18n %}
-{% load gravatar %}
+{% load trans from i18n %}
+{% load gravatar_url from gravatar %}
 
-{% load organizations %}
+{% load has_sso_enabled from organizations %}
 
-{% block title %}{{ organization.name }}{% endblock %}
+{% block title %}
+  {{ organization.name }}
+{% endblock title %}
 
 {# djlint:off #}
 {% block meta_title %}{{ organization.name }}{% endblock meta_title %}
@@ -14,7 +16,7 @@
 
 {% block content-header %}
   {% include "organizations/partials/header.html" with organization=organization projects_active="active" %}
-{% endblock %}
+{% endblock content-header %}
 
 {% block content %}
   {% if organization|has_sso_enabled:"allauth" %}

--- a/readthedocsext/theme/templates/profiles/public/profile_detail.html
+++ b/readthedocsext/theme/templates/profiles/public/profile_detail.html
@@ -3,7 +3,14 @@
 {% load i18n %}
 {% load privacy_tags %}
 
-{% block title %}{% blocktrans with profile.user as user %}{{ user }}'s profile{% endblocktrans %}{% endblock %}
+{% block title %}
+  {% blocktrans with profile.user as user %}{{ user }}'s profile{% endblocktrans %}
+{% endblock %}
+
+{# djlint:off #}
+{% block meta_title %}{{ profile.user }}'s profile{% endblock meta_title %}
+{% block meta_description %}{{ profile.user }}'s projects on Read the Docs{% endblock meta_description %}
+{# djlint:on #}
 
 {% block content %}
   <div class="ui stackable computer reversed grid">

--- a/readthedocsext/theme/templates/profiles/public/profile_detail.html
+++ b/readthedocsext/theme/templates/profiles/public/profile_detail.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% load i18n %}
-{% load privacy_tags %}
+{% load blocktrans from i18n %}
+{% load get_public_projects from privacy_tags %}
 
 {% block title %}
   {% blocktrans with profile.user as user %}{{ user }}'s profile{% endblocktrans %}
-{% endblock %}
+{% endblock title %}
 
 {# djlint:off #}
 {% block meta_title %}{{ profile.user }}'s profile{% endblock meta_title %}
@@ -25,4 +25,4 @@
       {% include "profiles/partials/profile_project_list.html" with objects=project_list objects=public_projects %}
     </div>
   </div>
-{% endblock %}
+{% endblock content %}

--- a/readthedocsext/theme/templates/profiles/public/profile_detail.html
+++ b/readthedocsext/theme/templates/profiles/public/profile_detail.html
@@ -8,8 +8,8 @@
 {% endblock title %}
 
 {# djlint:off #}
-{% block meta_title %}{{ profile.user }}'s profile{% endblock meta_title %}
-{% block meta_description %}{{ profile.user }}'s projects on Read the Docs{% endblock meta_description %}
+{% block meta_title %}{% blocktrans with user=profile.user %}{{ user }}'s profile{% endblocktrans %}{% endblock meta_title %}
+{% block meta_description %}{% blocktrans with user=profile.user %}{{ user }}'s projects on Read the Docs{% endblocktrans %}{% endblock meta_description %}
 {# djlint:on #}
 
 {% block content %}

--- a/readthedocsext/theme/templates/profiles/public/profile_detail.html
+++ b/readthedocsext/theme/templates/profiles/public/profile_detail.html
@@ -7,10 +7,16 @@
   {% blocktrans with profile.user as user %}{{ user }}'s profile{% endblocktrans %}
 {% endblock title %}
 
-{# djlint:off #}
-{% block meta_title %}{% blocktrans with user=profile.user %}{{ user }}'s profile{% endblocktrans %}{% endblock meta_title %}
-{% block meta_description %}{% blocktrans with user=profile.user %}{{ user }}'s projects on Read the Docs{% endblocktrans %}{% endblock meta_description %}
-{# djlint:on #}
+{% block head_meta %}
+  {% blocktrans with user=profile.user asvar og_title %}{{ user }}'s profile{% endblocktrans %}
+  {% blocktrans with user=profile.user asvar og_description %}{{ user }}'s projects on Read the Docs{% endblocktrans %}
+  <meta name="description" content="{{ og_description }}" />
+  <meta property="og:title" content="{{ og_title }}" />
+  <meta property="og:description" content="{{ og_description }}" />
+  <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Read the Docs" />
+{% endblock head_meta %}
 
 {% block content %}
   <div class="ui stackable computer reversed grid">

--- a/readthedocsext/theme/templates/projects/project_detail.html
+++ b/readthedocsext/theme/templates/projects/project_detail.html
@@ -6,6 +6,11 @@
 
 {% block title %}{{ project.name }}{% endblock %}
 
+{# djlint:off #}
+{% block meta_title %}{{ project.name }}{% endblock meta_title %}
+{% block meta_description %}{% firstof project.description "Documentation project on Read the Docs" %}{% endblock meta_description %}
+{# djlint:on #}
+
 {% block content-header %}
   {% include "projects/partials/header.html" with overview_active="active" %}
 {% endblock %}

--- a/readthedocsext/theme/templates/projects/project_detail.html
+++ b/readthedocsext/theme/templates/projects/project_detail.html
@@ -1,10 +1,12 @@
 {% extends "projects/base.html" %}
 
-{% load projects_tags %}
+{% block body_class %}
+  project_detail
+{% endblock body_class %}
 
-{% block body_class %}project_detail{% endblock %}
-
-{% block title %}{{ project.name }}{% endblock %}
+{% block title %}
+  {{ project.name }}
+{% endblock title %}
 
 {# djlint:off #}
 {% block meta_title %}{{ project.name }}{% endblock meta_title %}
@@ -13,7 +15,7 @@
 
 {% block content-header %}
   {% include "projects/partials/header.html" with overview_active="active" %}
-{% endblock %}
+{% endblock content-header %}
 
 {% block content %}
   {% comment %}
@@ -26,4 +28,4 @@
   {% endcomment %}
 
   {% include "builds/partials/version_list.html" with objects=versions %}
-{% endblock %}
+{% endblock content %}

--- a/readthedocsext/theme/templates/projects/project_detail.html
+++ b/readthedocsext/theme/templates/projects/project_detail.html
@@ -1,5 +1,7 @@
 {% extends "projects/base.html" %}
 
+{% load trans from i18n %}
+
 {% block body_class %}
   project_detail
 {% endblock body_class %}
@@ -10,7 +12,7 @@
 
 {# djlint:off #}
 {% block meta_title %}{{ project.name }}{% endblock meta_title %}
-{% block meta_description %}{% firstof project.description "Documentation project on Read the Docs" %}{% endblock meta_description %}
+{% block meta_description %}{% if project.description %}{{ project.description }}{% else %}{% trans "Documentation project on Read the Docs" %}{% endif %}{% endblock meta_description %}
 {# djlint:on #}
 
 {% block content-header %}

--- a/readthedocsext/theme/templates/projects/project_detail.html
+++ b/readthedocsext/theme/templates/projects/project_detail.html
@@ -10,10 +10,17 @@
   {{ project.name }}
 {% endblock title %}
 
-{# djlint:off #}
-{% block meta_title %}{{ project.name }}{% endblock meta_title %}
-{% block meta_description %}{% if project.description %}{{ project.description }}{% else %}{% trans "Documentation project on Read the Docs" %}{% endif %}{% endblock meta_description %}
-{# djlint:on #}
+{% block head_meta %}
+  {% trans "Documentation project on Read the Docs" as default_description %}
+  <meta name="description"
+        content="{% firstof project.description default_description %}" />
+  <meta property="og:title" content="{{ project.name }}" />
+  <meta property="og:description"
+        content="{% firstof project.description default_description %}" />
+  <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Read the Docs" />
+{% endblock head_meta %}
 
 {% block content-header %}
   {% include "projects/partials/header.html" with overview_active="active" %}


### PR DESCRIPTION
When links to Read the Docs are shared in Slack or other services, there's no rich preview — just a bare URL. This adds OpenGraph meta tags so link previews show useful context at a glance.

**Framework in `base.html`:** Default `og:title`, `og:description`, `og:type`, and `og:site_name` tags with overridable `meta_title` and `meta_description` blocks. Any page can customize its preview by overriding those two blocks.

**Pages with custom OG metadata:**
- **Build detail** — shows build result and version, e.g. "Build passed for latest on my-project"
- **Project detail** — shows project name and description
- **Organization detail** — shows org name and description
- **Profile detail** — shows username

Build detail uses `Build.get_result_display` (added in the companion [readthedocs.org PR](https://github.com/readthedocs/readthedocs.org/pull/new/claude/kind-planck-45KWp)) which centralizes the passed/failed/cancelled/building logic on the model.

---
*Generated by Claude Code*