### PR TITLE
Redirects: Fix redirect move buttons on paginated lists

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
+++ b/readthedocsext/theme/templates/projects/partials/edit/redirect_list.html
@@ -35,7 +35,8 @@
 {% block list_item_right_buttons %}
   {% trans "Move up" as button_up_text %}
   {% trans "Move down" as button_down_text %}
-  {% if not forloop.first %}
+  {# Show the "move up" button unless this is the very first redirect across all pages. #}
+  {% if not forloop.first or page_obj.has_previous %}
     <button class="ui icon button"
             data-bind="click: $root.post_child_form"
             data-content="{{ button_up_text }}"
@@ -49,7 +50,8 @@
     </button>
   {% endif %}
 
-  {% if not forloop.last %}
+  {# Show the "move down" button unless this is the very last redirect across all pages. #}
+  {% if not forloop.last or page_obj.has_next %}
     <button class="ui icon button"
             data-bind="click: $root.post_child_form"
             data-content="{{ button_down_text }}"


### PR DESCRIPTION
Fix the "move up" and "move down" buttons for redirects when viewing paginated lists.

Previously, the buttons were only shown based on the position within the current page (`forloop.first` and `forloop.last`). This meant that redirects on the first page couldn't move up, and redirects on the last page couldn't move down, even though they should be movable across page boundaries.

Fixes https://github.com/readthedocs/readthedocs.org/issues/12992

---

*Generated by AI agent*

https://claude.ai/code/session_0148moqMTkHDPxkcvuA4NanS