### PR TITLE
organizations: fix empty team list for SSO organizations

### DIFF
--- a/readthedocsext/theme/templates/organizations/team_list.html
+++ b/readthedocsext/theme/templates/organizations/team_list.html
@@ -1,18 +1,18 @@
 {% extends "organizations/base.html" %}
 
-{% load i18n %}
+{% load trans from i18n %}
 
-{% load organizations %}
+{% load has_sso_enabled from organizations %}
 
-{% block title %}{{ organization.name }} - {% trans "Teams" %}{% endblock %}
+{% block title %}{{ organization.name }} - {% trans "Teams" %}{% endblock title %}
 
 {% block content-header %}
   {% include "organizations/partials/header.html" with organization=organization teams_active="active" %}
-{% endblock %}
+{% endblock content-header %}
 
 {% block content %}
   {% if organization|has_sso_enabled:"allauth" %}
-    {% include "organizations/partials/has_sso/team_list.html" %}
+    {% include "organizations/partials/has_sso/team_list.html" with objects=teams %}
   {% else %}
     {% include "organizations/partials/team_list.html" with objects=teams %}
   {% endif %}


### PR DESCRIPTION
For organizations with SSO enabled, the Teams page always rendered an empty list: the SSO branch of `organizations/team_list.html` included its list partial without passing `objects`, so the shared table template had nothing to iterate. The non-SSO branch — and the sibling SSO includes for members and projects — all pass `objects` correctly; this was found in passing while auditing dashboard pagination for readthedocs/readthedocs.org#13210.

The touched file also carried four pre-existing template-lint findings (wildcard `{% load %}`s and unnamed `{% endblock %}`s) that CI's changed-files pre-commit run would now flag, so they are fixed here as well.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BB6HHBjvZJsSgYC1aL1N2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB6HHBjvZJsSgYC1aL1N2p)_