### PR TITLE
Errors: add proxito error page for disabled organizations

### DIFF
--- a/readthedocsext/theme/templates/errors/proxito/organization_disabled.html
+++ b/readthedocsext/theme/templates/errors/proxito/organization_disabled.html
@@ -1,0 +1,40 @@
+{% extends "errors/proxito/base.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block title %}
+  {% trans "Documentation unavailable" %}
+{% endblock title %}
+
+{% block error_status %}
+  404
+{% endblock error_status %}
+{% block error_title %}
+  {{ block.super }}
+  {% trans "Documentation unavailable" %}
+{% endblock error_title %}
+
+{% block error_content %}
+  <p>
+    {% blocktrans trimmed %}
+      This documentation is not available because the organization that owns it is disabled.
+    {% endblocktrans %}
+  </p>
+{% endblock error_content %}
+
+{% block error_content_help %}
+  <p>
+    {% blocktrans trimmed %}
+      If you are an owner of this organization, renew your subscription to restore your documentation.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% url 'support' as url_support %}
+    {% blocktrans trimmed with url_support=url_support %}
+      Please <a href="{{ url_support }}">contact us</a> if you think this is a mistake.
+    {% endblocktrans %}
+  </p>
+{% endblock error_content_help %}
+
+{% block content_extra_link %}
+{% endblock content_extra_link %}


### PR DESCRIPTION
readthedocs.org is gaining a serve-time check that stops serving docs for organizations that have been disabled for ~90 days (readthedocs/readthedocs.org#13238). Readers hitting docs of such an organization get this explicit error page instead of a bare 404, so the organization's own users understand why the docs vanished and owners know renewing the subscription restores them.

readthedocs.org ships a plain fallback copy of this template so its CI doesn't depend on this PR; since ext-theme templates take precedence over community ones, this styled version is the one that renders in production once it merges.

Modeled on the existing spam error page (served with a 404 status so long-dead orgs drop out of search indexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)