### PR TITLE
projects: explain the empty repository list on the add project page

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_automatic.html
@@ -113,80 +113,7 @@
     </div>
     <div class="content">
       <div class="ui segment">
-        <div class="ui small divided items">
-
-          {% if "githubapp" in socialaccount_providers %}
-            <div class="item">
-              <div class="content">
-                <div class="description">
-                  {% comment %}
-                    This terminology comes from the documentation for GitHub App management.
-                    Our GHA is "installed" for users or organizations and GitHub users
-                    "grant access to repositories" (or on the GHA installation page
-                    "install GHA _for repositories_").
-                  {% endcomment %}
-                  {# TODO detect if users have only installed on individual repositories so we can be more definite with this guidance #}
-                  {% blocktrans trimmed %}
-                    If our GitHub App was only granted access to select repositories,
-                    repositories without access will not display in your repository list.
-                    You will need to grant access to additional repositories each time you create a project.
-                  {% endblocktrans %}
-                </div>
-                <div class="extra">
-                  <a class="ui right floated button"
-                     href="https://github.com/apps/{{ GITHUB_APP_NAME }}/installations/new/"
-                     target="_blank">
-                    <i class="fa-brands fa-github icon"></i>
-                    {% trans "Update GitHub App installation" %}
-                  </a>
-                </div>
-              </div>
-            </div>
-          {% endif %}
-
-          {# This should show for all providers and manually connected repositories #}
-          <div class="item">
-            <div class="content">
-              <div class="description">
-                {% blocktrans trimmed %}
-                  Your connected service account might be out of sync
-                  and a manual refresh may be required to update your list of repositories.
-                {% endblocktrans %}
-              </div>
-              <div class="extra">
-                <a class="ui right floated button"
-                   data-bind="click: sync_remote_repos, css: {disabled: is_syncing(), loading: is_syncing(), positive: is_synced()}">
-                  <i class="fa-duotone fa-refresh icon"
-                     data-bind="css: {'fa-refresh': !is_synced(), 'fa-check': is_synced()}"></i>
-                  {% trans "Refresh your repositories" %}
-                </a>
-              </div>
-            </div>
-          </div>
-
-          {% if "github" in socialaccount_providers %}
-            {# This doesn't cover GitHub App providers, the fix for GHA is different #}
-            <div class="item">
-              <div class="content">
-                <div class="description">
-                  {% blocktrans trimmed %}
-                    If your repository list does not include repositories from one of your GitHub organizations,
-                    our GitHub application may not be approved by the organization yet.
-                    In this case, you should try requesting approval of our GitHub application from the organization.
-                  {% endblocktrans %}
-                </div>
-                <div class="extra">
-                  <a class="ui right floated button"
-                     href="https://docs.readthedocs.com/platform/stable/reference/git-integration.html#github-permission-troubleshooting">
-                    <i class="fa-duotone fa-circle-check icon"></i>
-                    {% trans "Learn how to request approval" %}
-                  </a>
-                </div>
-              </div>
-            </div>
-          {% endif %}
-
-        </div>
+        {% include "projects/partials/project_create_repair_items.html" %}
       </div>
     </div>
     <div class="actions">
@@ -198,23 +125,68 @@
 {% block project_add_automatic_placeholder %}
   <div class="ui basic horizontally fitted segment"
        data-bind="visible: !is_selected()">
-    <div class="ui top attached placeholder segment">
-      <div class="ui icon header">
-        {# Push user towards searching using input above #}
-        <i class="fad fa-search icon"></i>
-        {% trans "Select a repository" %}
+    {% comment %}
+      The explicit False comparisons keep these states off until the
+      application side ships the context variables — an undefined variable
+      falls through to the previous placeholder instead of showing the
+      "connect a provider" state to everyone.
+    {% endcomment %}
+    {% if has_connected_vcs_account == False %}
+      {# No Git provider connected: searching can never return results #}
+      <div class="ui top attached placeholder segment">
+        <div class="ui icon header">
+          <i class="fad fa-plug icon"></i>
+          {% trans "Connect a Git provider" %}
 
-        <div class="sub header">
-          {# User has connected accounts, don't point to connecting GitHub/etc #}
-          {% blocktrans trimmed %}
-            Use the search above to find the repository you would like to
-            use to build your new project. This project will be connected to
-            the repository through your connected account.
-          {% endblocktrans %}
+          <div class="sub header">
+            {% blocktrans trimmed %}
+              Your account isn't connected to GitHub, Bitbucket, or GitLab yet.
+              Connect a provider to choose from a list of your repositories.
+            {% endblocktrans %}
+          </div>
+        </div>
+        <a class="ui primary button"
+           href="{% url 'socialaccount_connections' %}">
+          {% trans "Connect a provider" %}
+        </a>
+      </div>
+    {% elif has_remote_repositories == False %}
+      {# Provider connected but no repositories synced: explain the likely fixes inline #}
+      <div class="ui top attached placeholder segment">
+        <div class="ui icon header">
+          <i class="fad fa-search icon"></i>
+          {% trans "No repositories found yet" %}
+
+          <div class="sub header">
+            {% blocktrans trimmed %}
+              We can't see any repositories on your connected account yet.
+              This usually has a quick fix:
+            {% endblocktrans %}
+          </div>
         </div>
       </div>
+      <div class="ui bottom attached segment">
+        {% include "projects/partials/project_create_repair_items.html" %}
+      </div>
+    {% else %}
+      <div class="ui top attached placeholder segment">
+        <div class="ui icon header">
+          {# Push user towards searching using input above #}
+          <i class="fad fa-search icon"></i>
+          {% trans "Select a repository" %}
 
-    </div>
+          <div class="sub header">
+            {# User has connected accounts, don't point to connecting GitHub/etc #}
+            {% blocktrans trimmed %}
+              Use the search above to find the repository you would like to
+              use to build your new project. This project will be connected to
+              the repository through your connected account.
+            {% endblocktrans %}
+          </div>
+        </div>
+
+      </div>
+    {% endif %}
   </div>
 {% endblock project_add_automatic_placeholder %}
 

--- a/readthedocsext/theme/templates/projects/partials/project_create_repair_items.html
+++ b/readthedocsext/theme/templates/projects/partials/project_create_repair_items.html
@@ -1,0 +1,104 @@
+{% load trans blocktrans from i18n %}
+
+{% comment rst %}
+  Repository list repair items
+  ============================
+
+  The common fixes for a missing or empty repository list. Included in two
+  places on the project import page: inline, when the user's repository list
+  is empty on page load, and in the "Repair" modal behind the search popup.
+
+  Expects the import view context: ``socialaccount_providers``,
+  ``has_github_app_repositories``, and ``GITHUB_APP_NAME``.
+{% endcomment %}
+
+<div class="ui small divided items">
+
+  {% if "githubapp" in socialaccount_providers %}
+    <div class="item">
+      <div class="content">
+        <div class="description">
+          {% comment %}
+            This terminology comes from the documentation for GitHub App management.
+            Our GHA is "installed" for users or organizations and GitHub users
+            "grant access to repositories" (or on the GHA installation page
+            "install GHA _for repositories_").
+          {% endcomment %}
+          {% comment %}
+            The explicit False comparison keeps the install-first copy off
+            until the application side ships this context variable — an
+            undefined variable falls through to the previous copy.
+          {% endcomment %}
+          {% if has_github_app_repositories == False %}
+            {% blocktrans trimmed %}
+              Our GitHub App doesn't have access to any of your repositories yet.
+              Install the app on your GitHub account or organization, and grant it
+              access to the repositories you want to build.
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans trimmed %}
+              If our GitHub App was only granted access to select repositories,
+              repositories without access will not display in your repository list.
+              You will need to grant access to additional repositories each time you create a project.
+            {% endblocktrans %}
+          {% endif %}
+        </div>
+        <div class="extra">
+          <a class="ui right floated button"
+             href="https://github.com/apps/{{ GITHUB_APP_NAME }}/installations/new/"
+             target="_blank">
+            <i class="fa-brands fa-github icon"></i>
+            {% if has_github_app_repositories == False %}
+              {% trans "Install GitHub App" %}
+            {% else %}
+              {% trans "Update GitHub App installation" %}
+            {% endif %}
+          </a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  {# This should show for all providers and manually connected repositories #}
+  <div class="item">
+    <div class="content">
+      <div class="description">
+        {% blocktrans trimmed %}
+          Your connected service account might be out of sync
+          and a manual refresh may be required to update your list of repositories.
+        {% endblocktrans %}
+      </div>
+      <div class="extra">
+        <a class="ui right floated button"
+           data-bind="click: sync_remote_repos, css: {disabled: is_syncing(), loading: is_syncing(), positive: is_synced()}">
+          <i class="fa-duotone fa-refresh icon"
+             data-bind="css: {'fa-refresh': !is_synced(), 'fa-check': is_synced()}"></i>
+          {% trans "Refresh your repositories" %}
+        </a>
+      </div>
+    </div>
+  </div>
+
+  {% if "github" in socialaccount_providers or "githubapp" in socialaccount_providers %}
+    {# Organization owners approve access for the GitHub App and OAuth app alike #}
+    <div class="item">
+      <div class="content">
+        <div class="description">
+          {% blocktrans trimmed %}
+            If your repository list does not include repositories from one of your GitHub organizations,
+            our GitHub application may not be approved by the organization yet.
+            In this case, you should try requesting approval of our GitHub application from the organization.
+          {% endblocktrans %}
+        </div>
+        <div class="extra">
+          <a class="ui right floated button"
+             href="https://docs.readthedocs.com/platform/stable/reference/git-integration.html#github-permission-troubleshooting">
+            <i class="fa-duotone fa-circle-check icon"></i>
+            {% trans "Learn how to request approval" %}
+          </a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+</div>

--- a/readthedocsext/theme/templates/projects/partials/project_list.html
+++ b/readthedocsext/theme/templates/projects/partials/project_list.html
@@ -24,9 +24,11 @@
   {% trans "You don't have any projects configured yet" %}
 {% endblock list_placeholder_header_empty %}
 {% block list_placeholder_text_empty %}
+  {% url "projects_import" as import_url %}
+  <a href="{{ import_url }}" class="ui primary button">{% trans "Add your first project" %}</a>
   <a href="https://docs.readthedocs.io/page/tutorial/"
      target="_blank"
-     class="ui primary button">{% trans "Learn how to get started" %}</a>
+     class="ui button">{% trans "Learn how to get started" %}</a>
 {% endblock list_placeholder_text_empty %}
 
 {% block list_item_right_menu %}

--- a/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
+++ b/readthedocsext/theme/templates/socialaccount/partials/social_account_list.html
@@ -31,7 +31,7 @@
   {% endblocktrans %}
   <div class="sub header">
     {% blocktrans trimmed %}
-      Add a new connection to to enable automatic import and
+      Add a new connection to enable automatic import and
       configuration of new projects.
     {% endblocktrans %}
   </div>


### PR DESCRIPTION
A user who lands on the add project page with an empty repository list currently gets a search box that can never return results, and the guidance that would fix their situation (install the GitHub App, refresh the sync, request organization approval) is hidden behind the "Repair" popup that only appears after a failed search. Users who signed up with Google alone get the same dead end with no hint that they need to connect a Git provider at all.

This shows the right guidance inline on first load, branching on context from readthedocs/readthedocs.org#13244: no Git provider connected → connect prompt; connected but nothing synced → the repair guidance, with the GitHub App item distinguishing "never installed" from "installed but restricted". The organization-approval item previously rendered only for the legacy OAuth provider — explicitly not for the GitHub App, whose users are the ones that hit pending-approval installs — so it now covers both. The repair items move to a shared partial so the inline state and the Repair modal stay in sync. The dashboard's empty state also gains an Add project button; it previously only linked the tutorial.

Merge order is safe in both directions: the new states key on explicit `== False` comparisons, so until the application PR deploys, undefined context falls through to the current placeholder rather than showing the connect prompt to everyone. Worth double-checking that reasoning in review, since it's load-bearing.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yjYstmBb2HiscZUc5eKH4)_