### PR TITLE
projects: reword pull request previews announcement

### DIFF
--- a/readthedocsext/theme/templates/projects/partials/announcements/pull-request-previews.html
+++ b/readthedocsext/theme/templates/projects/partials/announcements/pull-request-previews.html
@@ -9,15 +9,15 @@
         <a class="header" target="_blank" href="{{ url }}">{% trans "Preview changes before deploying!" %}</a>
         <div class="description">
           {% blocktrans %}
-            Automatically build, preview, and share documentation with every pull request
-            and easily catch issues before going live.
+            We build a preview of your documentation for every pull request,
+            so you can catch issues before they go live.
           {% endblocktrans %}
         </div>
       </div>
       <div class="ui extra content">
         <a class="ui small primary fluid basic button"
            target="_blank"
-           href="{{ url }}">{% trans "Enable pull request previews" %}</a>
+           href="{{ url }}">{% trans "Learn about pull request previews" %}</a>
       </div>
     </div>
   </div>

--- a/readthedocsext/theme/templates/projects/partials/announcements/pull-request-previews.html
+++ b/readthedocsext/theme/templates/projects/partials/announcements/pull-request-previews.html
@@ -9,7 +9,7 @@
         <a class="header" target="_blank" href="{{ url }}">{% trans "Preview changes before deploying!" %}</a>
         <div class="description">
           {% blocktrans %}
-            We build a preview of your documentation for every pull request,
+            Every pull request gets a preview of your documentation,
             so you can catch issues before they go live.
           {% endblocktrans %}
         </div>


### PR DESCRIPTION
Pairs with readthedocs/readthedocs.org#13249, which makes pull request builds default to on and keeps this dashboard announcement visible until the user actually has a pull request preview.

Once the setting is on by default, "Enable pull request previews" asks people to do something already done for them. The copy now describes what happens when they open a pull request, and points at the docs to learn more.

Land this alongside the other pull request, otherwise the announcement's call to action no longer matches when it appears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvLJgam4eFipmYnijL4bZY)_